### PR TITLE
add jsnext and module entry points

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   },
   "source": "src/index.ts",
   "main": "dist/index.js",
+  "module": "dist/index.js",
+  "jsnext:main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Howdy. Great looking charts!

I believe you need to add the "jsnext:main" and "module" entry points so your project is tree shakeable.  Right now  if you look on [bundlephobia](https://bundlephobia.com/result?p=reaviz@1.0.1) it looks like you need to import all 129kb to use any chart.  Tools like rollup and webpack use those fields to understand what type of code is being loaded.

#### More info here [package.module](https://github.com/rollup/rollup/wiki/pkg.module)

<img width="846" alt="screen shot 2019-03-07 at 3 39 09 pm" src="https://user-images.githubusercontent.com/4615775/53994354-5e99a600-40ef-11e9-86c7-1234439bb977.png">

You export es modules so it should show as shakeable.  You'll get the little "leaf" like you see here on d3 then:
<img width="652" alt="screen shot 2019-03-07 at 3 41 23 pm" src="https://user-images.githubusercontent.com/4615775/53994429-8721a000-40ef-11e9-8524-cce7d5a40fc7.png">
