### PR TITLE
Sankey diagram: SankeyNode/Link: Disabled style changes

### DIFF
--- a/src/Sankey/Sankey.tsx
+++ b/src/Sankey/Sankey.tsx
@@ -55,7 +55,7 @@ export class Sankey extends Component<SankeyProps, SankeyState> {
 
   state: SankeyState = { activeNodes: [], activeLinks: [] };
 
-  getColor(node: JSX.Element, index: any) {
+  getNodeColor(node: JSX.Element, index: any) {
     const { colorScheme, nodes } = this.props;
 
     if (colorScheme) {
@@ -171,7 +171,7 @@ export class Sankey extends Component<SankeyProps, SankeyState> {
     const nodesCopy: Node[] = this.props.nodes.map((node, index) => ({
       id: node.props.id,
       title: node.props.title,
-      color: this.getColor(node, index)
+      color: this.getNodeColor(node, index)
     }));
 
     const linksCopy: Link[] = this.props.links.map(link => ({

--- a/src/Sankey/SankeyLabel/SankeyLabel.tsx
+++ b/src/Sankey/SankeyLabel/SankeyLabel.tsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import classNames from 'classnames';
+import { isString } from 'lodash-es';
 import { Node } from '../utils';
 import * as css from './SankeyLabel.module.scss';
 
@@ -7,11 +8,12 @@ export type Location = 'inside' | 'outside';
 
 export interface SankeyLabelProps {
   active: boolean;
-  className?: string;
   chartWidth?: number;
+  className?: string;
   fill: string;
   location: Location;
   node?: Node;
+  opacity: (active: boolean) => number;
   padding?: string | number;
   visible: boolean;
 }
@@ -21,19 +23,22 @@ export class SankeyLabel extends Component<SankeyLabelProps> {
     active: false,
     fill: '#fff',
     location: 'outside', // TODO: implement for inside
+    opacity: active => active ? 1 : 0.5,
     visible: true
   };
 
   render() {
     const {
       active,
+      chartWidth,
       className,
       fill,
       node,
+      opacity,
       padding,
-      chartWidth,
       visible
     } = this.props;
+
     const nodePositions = {
       x0: node && node.x0 ? node.x0 : 0,
       y0: node && node.y0 ? node.y0 : 0,
@@ -53,10 +58,10 @@ export class SankeyLabel extends Component<SankeyLabelProps> {
           dy="0.35em"
           textAnchor={textAnchor}
           fill={fill}
-          opacity={active ? 1 : 0.5}
+          opacity={opacity(active)}
           style={{ padding }}
         >
-          {node ? node.title : 0}
+          {node.title}
         </text>
       )
     );

--- a/src/Sankey/SankeyLink/SankeyLink.module.scss
+++ b/src/Sankey/SankeyLink/SankeyLink.module.scss
@@ -4,10 +4,6 @@
   mix-blend-mode: screen;
 }
 
-.disabled {
-  opacity: 0.1;
-}
-
 .tooltip {
   text-align: center;
 

--- a/src/Sankey/SankeyLink/SankeyLink.module.scss
+++ b/src/Sankey/SankeyLink/SankeyLink.module.scss
@@ -2,6 +2,10 @@
   fill: none;
   transition: stroke-opacity 100ms ease-in-out, stroke 100ms ease-in-out;
   mix-blend-mode: screen;
+
+  &.disabled {
+    opacity: 0.1;
+  }
 }
 
 .tooltip {

--- a/src/Sankey/SankeyLink/SankeyLink.module.scss
+++ b/src/Sankey/SankeyLink/SankeyLink.module.scss
@@ -2,10 +2,10 @@
   fill: none;
   transition: stroke-opacity 100ms ease-in-out, stroke 100ms ease-in-out;
   mix-blend-mode: screen;
+}
 
-  &.disabled {
-    opacity: 0.1;
-  }
+.disabled {
+  opacity: 0.1;
 }
 
 .tooltip {

--- a/src/Sankey/SankeyLink/SankeyLink.tsx
+++ b/src/Sankey/SankeyLink/SankeyLink.tsx
@@ -42,13 +42,6 @@ interface SankeyLinkState {
   hovered?: boolean;
 }
 
-// Set padding modifier for the tooltips
-export const modifiers = {
-  offset: {
-    offset: '0, 5px'
-  }
-};
-
 export class SankeyLink extends Component<SankeyLinkProps, SankeyLinkState> {
   static defaultProps: Partial<SankeyLinkProps> = {
     active: false,
@@ -57,7 +50,11 @@ export class SankeyLink extends Component<SankeyLinkProps, SankeyLinkState> {
     disabled: false,
     gradient: true,
     opacity: active => active ? 0.5 : 0.35,
-    tooltip: <Tooltip followCursor={true} modifiers={modifiers} />,
+    tooltip: <Tooltip followCursor={true} modifiers={{
+      offset: {
+        offset: '0, 5px'
+      }
+    }} />,
     width: 0,
     onClick: () => undefined,
     onMouseEnter: () => undefined,

--- a/src/Sankey/SankeyLink/SankeyLink.tsx
+++ b/src/Sankey/SankeyLink/SankeyLink.tsx
@@ -115,9 +115,9 @@ export class SankeyLink extends Component<SankeyLinkProps, SankeyLinkState> {
         pose="enter"
         poseKey={`sankey-link-${enterProps.d}-${index}`}
         animated={animated}
-        className={classNames(css.link, {
+        className={classNames(css.link, className, {
           [css.disabled]: disabled
-        }, className)}
+        })}
         style={style}
         ref={this.link}
         enterProps={enterProps}

--- a/src/Sankey/SankeyLink/SankeyLink.tsx
+++ b/src/Sankey/SankeyLink/SankeyLink.tsx
@@ -25,12 +25,14 @@ export const PosedLink = posed.path({
 export interface SankeyLinkProps extends Link {
   active: boolean;
   animated: boolean;
-  disabled: boolean;
-  className?: string;
-  gradient?: boolean;
-  style?: object;
   chartId: string;
+  className?: string;
+  disabled: boolean;
+  gradient?: boolean;
+  opacity: (active: boolean) => number;
+  style?: object;
   tooltip: JSX.Element;
+  width: number;
   onClick: (event: React.MouseEvent<SVGPathElement>) => void;
   onMouseEnter: (event: React.MouseEvent<SVGPathElement>) => void;
   onMouseLeave: (event: React.MouseEvent<SVGPathElement>) => void;
@@ -41,7 +43,7 @@ interface SankeyLinkState {
 }
 
 // Set padding modifier for the tooltips
-const modifiers = {
+export const modifiers = {
   offset: {
     offset: '0, 5px'
   }
@@ -52,9 +54,11 @@ export class SankeyLink extends Component<SankeyLinkProps, SankeyLinkState> {
     active: false,
     animated: true,
     color: DEFAULT_COLOR,
-    gradient: true,
     disabled: false,
-    tooltip: <Tooltip followCursor={true} />,
+    gradient: true,
+    opacity: active => active ? 0.5 : 0.35,
+    tooltip: <Tooltip followCursor={true} modifiers={modifiers} />,
+    width: 0,
     onClick: () => undefined,
     onMouseEnter: () => undefined,
     onMouseLeave: () => undefined
@@ -63,23 +67,27 @@ export class SankeyLink extends Component<SankeyLinkProps, SankeyLinkState> {
   link = createRef<SVGPathElement>();
   state: SankeyLinkState = {};
 
+  getEnter() {
+    const path = sankeyLinkHorizontal();
+    const d = path(this.getLink());
+    const strokeWidth = Math.max(1, this.props.width);
+    return { d, strokeWidth };
+  }
+
+  getExit() {
+    const path = sankeyLinkHorizontal();
+    const d = path({ ...this.getLink(), width: 0 });
+    return { d, strokeWidth: 0 };
+  }
+
   getLink() {
     const { index, value, y0, y1, source, target, width } = this.props;
     return { index, y0, y1, value, width, source, target };
   }
 
   getStroke() {
-    const { color, disabled, index, gradient, chartId } = this.props;
-
-    if (disabled) {
-      return DEFAULT_COLOR;
-    }
-
-    if (gradient) {
-      return `url(#${chartId}-gradient-${index})`;
-    }
-
-    return color;
+    const { color, index, gradient, chartId } = this.props;
+    return gradient ? `url(#${chartId}-gradient-${index})` : color;
   }
 
   onMouseEnter(event: React.MouseEvent<SVGPathElement>) {
@@ -92,36 +100,17 @@ export class SankeyLink extends Component<SankeyLinkProps, SankeyLinkState> {
     this.props.onMouseLeave(event);
   }
 
-  getEnter() {
-    const path = sankeyLinkHorizontal();
-    const d = path(this.getLink());
-    const strokeWidth = Math.max(1, this.props.width || 0);
-    return { d, strokeWidth };
-  }
-
-  getExit() {
-    const path = sankeyLinkHorizontal();
-    const d = path({ ...this.getLink(), width: 0 });
-    return { d, strokeWidth: 0 };
-  }
-
   renderLink() {
     const {
       active,
       animated,
       className,
-      color,
-      gradient,
-      style,
+      disabled,
       index,
+      opacity,
+      style,
       onClick
     } = this.props;
-    const useNoGradientNoColorOpacity = !gradient && color === DEFAULT_COLOR;
-    const strokeOpacity = active
-      ? useNoGradientNoColorOpacity
-        ? 1
-        : 0.5
-      : 0.35;
     const enterProps = this.getEnter();
 
     return (
@@ -129,13 +118,15 @@ export class SankeyLink extends Component<SankeyLinkProps, SankeyLinkState> {
         pose="enter"
         poseKey={`sankey-link-${enterProps.d}-${index}`}
         animated={animated}
-        className={classNames(css.link, className)}
+        className={classNames(css.link, {
+          [css.disabled]: disabled
+        }, className)}
         style={style}
         ref={this.link}
         enterProps={enterProps}
         exitProps={this.getExit()}
         stroke={this.getStroke()}
-        strokeOpacity={strokeOpacity}
+        strokeOpacity={opacity(active)}
         onClick={onClick}
         onMouseEnter={bind(this.onMouseEnter, this)}
         onMouseLeave={bind(this.onMouseLeave, this)}
@@ -158,7 +149,6 @@ export class SankeyLink extends Component<SankeyLinkProps, SankeyLinkState> {
 
   render() {
     const { gradient, index, source, target, tooltip, chartId } = this.props;
-    const { hovered } = this.state;
     const linkSource = source as Node;
     const linkTarget = target as Node;
 
@@ -180,8 +170,7 @@ export class SankeyLink extends Component<SankeyLinkProps, SankeyLinkState> {
           <CloneElement<TooltipProps>
             content={this.renderTooltipContent.bind(this)}
             element={tooltip}
-            modifiers={modifiers}
-            visible={hovered}
+            visible={this.state.hovered}
             reference={this.link}
           />
         )}

--- a/src/Sankey/SankeyLink/SankeyLink.tsx
+++ b/src/Sankey/SankeyLink/SankeyLink.tsx
@@ -29,7 +29,7 @@ export interface SankeyLinkProps extends Link {
   className?: string;
   disabled: boolean;
   gradient?: boolean;
-  opacity: (active: boolean) => number;
+  opacity: (active: boolean, disabled: boolean) => number;
   style?: object;
   tooltip: JSX.Element;
   width: number;
@@ -49,12 +49,17 @@ export class SankeyLink extends Component<SankeyLinkProps, SankeyLinkState> {
     color: DEFAULT_COLOR,
     disabled: false,
     gradient: true,
-    opacity: active => active ? 0.5 : 0.35,
-    tooltip: <Tooltip followCursor={true} modifiers={{
-      offset: {
-        offset: '0, 5px'
-      }
-    }} />,
+    opacity: (active, disabled) => (active ? 0.5 : disabled ? 0.1 : 0.35),
+    tooltip: (
+      <Tooltip
+        followCursor={true}
+        modifiers={{
+          offset: {
+            offset: '0, 5px'
+          }
+        }}
+      />
+    ),
     width: 0,
     onClick: () => undefined,
     onMouseEnter: () => undefined,
@@ -115,15 +120,13 @@ export class SankeyLink extends Component<SankeyLinkProps, SankeyLinkState> {
         pose="enter"
         poseKey={`sankey-link-${enterProps.d}-${index}`}
         animated={animated}
-        className={classNames(css.link, className, {
-          [css.disabled]: disabled
-        })}
+        className={classNames(css.link, className)}
         style={style}
         ref={this.link}
         enterProps={enterProps}
         exitProps={this.getExit()}
         stroke={this.getStroke()}
-        strokeOpacity={opacity(active)}
+        strokeOpacity={opacity(active, disabled)}
         onClick={onClick}
         onMouseEnter={bind(this.onMouseEnter, this)}
         onMouseLeave={bind(this.onMouseLeave, this)}

--- a/src/Sankey/SankeyNode/SankeyNode.module.scss
+++ b/src/Sankey/SankeyNode/SankeyNode.module.scss
@@ -5,6 +5,10 @@
   &:hover {
     fill-opacity: 1;
   }
+
+  &.disabled {
+    opacity: 0.1;
+  }
 }
 
 .tooltip {

--- a/src/Sankey/SankeyNode/SankeyNode.module.scss
+++ b/src/Sankey/SankeyNode/SankeyNode.module.scss
@@ -1,14 +1,5 @@
 .node {
-  fill-opacity: 0.9;
-  transition: opacity 100ms ease-in-out;
-
-  &:hover {
-    fill-opacity: 1;
-  }
-}
-
-.disabled {
-  opacity: 0.1;
+  transition: opacity 100ms ease-in-out, fill-opacity 100ms ease-in-out;
 }
 
 .tooltip {

--- a/src/Sankey/SankeyNode/SankeyNode.module.scss
+++ b/src/Sankey/SankeyNode/SankeyNode.module.scss
@@ -5,10 +5,10 @@
   &:hover {
     fill-opacity: 1;
   }
+}
 
-  &.disabled {
-    opacity: 0.1;
-  }
+.disabled {
+  opacity: 0.1;
 }
 
 .tooltip {

--- a/src/Sankey/SankeyNode/SankeyNode.tsx
+++ b/src/Sankey/SankeyNode/SankeyNode.tsx
@@ -132,9 +132,9 @@ export class SankeyNode extends Component<SankeyNodeProps, SankeyNodeState> {
         pose="enter"
         poseKey={`sankey-node-${x0}-${x1}-${y0}-${y1}-${index}`}
         animated={animated}
-        className={classNames(css.node, {
+        className={classNames(css.node, className, {
           [css.disabled]: disabled
-        }, className)}
+        })}
         style={style}
         ref={this.rect}
         x={x0}

--- a/src/Sankey/SankeyNode/SankeyNode.tsx
+++ b/src/Sankey/SankeyNode/SankeyNode.tsx
@@ -35,6 +35,7 @@ export interface SankeyNodeProps extends Node {
   className?: string;
   disabled: boolean;
   label: JSX.Element;
+  opacity: (active: boolean, disabled: boolean) => number;
   showLabel: boolean;
   style?: object;
   tooltip: JSX.Element;
@@ -55,12 +56,18 @@ export class SankeyNode extends Component<SankeyNodeProps, SankeyNodeState> {
     color: DEFAULT_COLOR,
     disabled: false,
     label: <SankeyLabel />,
+    opacity: (active, disabled) => (active ? 1 : disabled ? 0.2 : 0.9),
     showLabel: true,
-    tooltip: <Tooltip followCursor={true} modifiers={{
-      offset: {
-        offset: '0, 5px'
-      }
-    }} />,
+    tooltip: (
+      <Tooltip
+        followCursor={true}
+        modifiers={{
+          offset: {
+            offset: '0, 5px'
+          }
+        }}
+      />
+    ),
     onClick: () => undefined,
     onMouseEnter: () => undefined,
     onMouseLeave: () => undefined
@@ -111,13 +118,15 @@ export class SankeyNode extends Component<SankeyNodeProps, SankeyNodeState> {
 
   renderNode() {
     const {
+      active,
       animated,
-      disabled,
       className,
-      style,
       color,
-      width,
+      disabled,
       index,
+      opacity,
+      style,
+      width,
       x0,
       x1,
       y0,
@@ -135,6 +144,7 @@ export class SankeyNode extends Component<SankeyNodeProps, SankeyNodeState> {
         className={classNames(css.node, className, {
           [css.disabled]: disabled
         })}
+        fillOpacity={opacity(active, disabled)}
         style={style}
         ref={this.rect}
         x={x0}

--- a/src/Sankey/SankeyNode/SankeyNode.tsx
+++ b/src/Sankey/SankeyNode/SankeyNode.tsx
@@ -19,7 +19,7 @@ export const PosedNode = posed.rect({
       opacity: {
         type: 'tween',
         ease: 'linear',
-        duration: 250
+        duration: 150
       }
     }
   },
@@ -31,14 +31,14 @@ export const PosedNode = posed.rect({
 export interface SankeyNodeProps extends Node {
   active: boolean;
   animated: boolean;
-  disabled: boolean;
-  className?: string;
-  style?: object;
   chartWidth?: number;
-  width?: number;
+  className?: string;
+  disabled: boolean;
   label: JSX.Element;
-  tooltip: JSX.Element;
   showLabel: boolean;
+  style?: object;
+  tooltip: JSX.Element;
+  width?: number;
   onClick: (event: React.MouseEvent<SVGRectElement>) => void;
   onMouseEnter: (event: React.MouseEvent<SVGRectElement>) => void;
   onMouseLeave: (event: React.MouseEvent<SVGRectElement>) => void;
@@ -49,7 +49,7 @@ interface SankeyNodeState {
 }
 
 // Set padding modifier for the tooltips
-const modifiers = {
+export const modifiers = {
   offset: {
     offset: '0, 5px'
   }
@@ -62,8 +62,8 @@ export class SankeyNode extends Component<SankeyNodeProps, SankeyNodeState> {
     color: DEFAULT_COLOR,
     disabled: false,
     label: <SankeyLabel />,
-    tooltip: <Tooltip />,
     showLabel: true,
+    tooltip: <Tooltip followCursor={true} modifiers={modifiers} />,
     onClick: () => undefined,
     onMouseEnter: () => undefined,
     onMouseLeave: () => undefined
@@ -135,14 +135,16 @@ export class SankeyNode extends Component<SankeyNodeProps, SankeyNodeState> {
         pose="enter"
         poseKey={`sankey-node-${x0}-${x1}-${y0}-${y1}-${index}`}
         animated={animated}
-        className={classNames(css.node, className)}
+        className={classNames(css.node, {
+          [css.disabled]: disabled
+        }, className)}
         style={style}
         ref={this.rect}
         x={x0}
         y={y0}
         width={nodeWidth}
         height={nodeHeight}
-        fill={disabled ? DEFAULT_COLOR : color}
+        fill={color}
         onClick={onClick}
         onMouseEnter={bind(this.onMouseEnter, this)}
         onMouseLeave={bind(this.onMouseLeave, this)}
@@ -165,7 +167,6 @@ export class SankeyNode extends Component<SankeyNodeProps, SankeyNodeState> {
 
   render() {
     const { active, chartWidth, label, tooltip, showLabel } = this.props;
-    const { hovered } = this.state;
 
     return (
       <Fragment>
@@ -182,8 +183,7 @@ export class SankeyNode extends Component<SankeyNodeProps, SankeyNodeState> {
           <CloneElement<TooltipProps>
             content={this.renderTooltipContent.bind(this)}
             element={tooltip}
-            modifiers={modifiers}
-            visible={hovered}
+            visible={this.state.hovered}
             reference={this.rect}
           />
         )}

--- a/src/Sankey/SankeyNode/SankeyNode.tsx
+++ b/src/Sankey/SankeyNode/SankeyNode.tsx
@@ -141,9 +141,7 @@ export class SankeyNode extends Component<SankeyNodeProps, SankeyNodeState> {
         pose="enter"
         poseKey={`sankey-node-${x0}-${x1}-${y0}-${y1}-${index}`}
         animated={animated}
-        className={classNames(css.node, className, {
-          [css.disabled]: disabled
-        })}
+        className={classNames(css.node, className)}
         fillOpacity={opacity(active, disabled)}
         style={style}
         ref={this.rect}

--- a/src/Sankey/SankeyNode/SankeyNode.tsx
+++ b/src/Sankey/SankeyNode/SankeyNode.tsx
@@ -48,13 +48,6 @@ interface SankeyNodeState {
   hovered?: boolean;
 }
 
-// Set padding modifier for the tooltips
-export const modifiers = {
-  offset: {
-    offset: '0, 5px'
-  }
-};
-
 export class SankeyNode extends Component<SankeyNodeProps, SankeyNodeState> {
   static defaultProps: Partial<SankeyNodeProps> = {
     active: false,
@@ -63,7 +56,11 @@ export class SankeyNode extends Component<SankeyNodeProps, SankeyNodeState> {
     disabled: false,
     label: <SankeyLabel />,
     showLabel: true,
-    tooltip: <Tooltip followCursor={true} modifiers={modifiers} />,
+    tooltip: <Tooltip followCursor={true} modifiers={{
+      offset: {
+        offset: '0, 5px'
+      }
+    }} />,
     onClick: () => undefined,
     onMouseEnter: () => undefined,
     onMouseLeave: () => undefined

--- a/src/Sankey/index.tsx
+++ b/src/Sankey/index.tsx
@@ -1,3 +1,4 @@
 export * from './Sankey';
-export * from './SankeyNode';
+export * from './SankeyLabel';
 export * from './SankeyLink';
+export * from './SankeyNode';


### PR DESCRIPTION
This PR makes the Sankey diagram to use opacity instead of color for the node/link when it's disabled:

<img width="1280" alt="Screen Shot 2019-03-20 at 1 37 27 PM (2)" src="https://user-images.githubusercontent.com/2556027/54718274-5beb7780-4b17-11e9-8dc2-9dc26ae3f5a7.png">


Also this PR includes:
- Make the SankeyLabel available from Sankey
- Refactored Sankey components to make them more customizable (e.g.: tooltip and opacity)