### PR TITLE
Fix a bug with gradient LinearAxisLines not working in Firefox

### DIFF
--- a/src/common/Axis/LinearAxis/LinearAxisLine.tsx
+++ b/src/common/Axis/LinearAxis/LinearAxisLine.tsx
@@ -40,10 +40,10 @@ export class LinearAxisLine extends Component<
       <Fragment>
         <line
           x1={orientation === 'vertical' ? 0 : range0}
-          // Workaround for a Chrome bug where it won't render gradients for straight lines
-          x2={orientation === 'vertical' ? 0.000001 : range1}
+          // Workaround for a Chrome/Firefox bug where it won't render gradients for straight lines
+          x2={orientation === 'vertical' ? 0.00001 : range1}
           y1={orientation === 'vertical' ? range0 : 0}
-          y2={orientation === 'vertical' ? range1 : 0.000001}
+          y2={orientation === 'vertical' ? range1 : 0.00001}
           strokeWidth={1}
           stroke={strokeGradient ? `url(#axis-gradient-${id})` : strokeColor}
         />


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
LinearAxisLines with gradients do not render in Firefox.
Issue Number: N/A


## What is the new behavior?
LinearAxisLines with gradients render correctly in Firefox.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Open this codepen in Firefox to how it does or doesn't work depending on whether x1 and x2 are too close together: https://codepen.io/anon/pen/dLdVxR