### PR TITLE
Various Radial Fixes

### DIFF
--- a/src/RadialAreaChart/RadialAreaSeries/RadialArea.tsx
+++ b/src/RadialAreaChart/RadialAreaSeries/RadialArea.tsx
@@ -49,13 +49,14 @@ export class RadialArea extends Component<RadialAreaProps> {
   }
 
   renderArea(fill: string) {
-    const { data, className, animated } = this.props;
+    const { data, className, animated, yScale } = this.props;
     const enterProps = {
       d: this.getPath(data)
     };
 
+    const [yStart] = yScale.domain();
     const exitProps = {
-      d: this.getPath(data.map(d => ({ ...d, y: 0 })))
+      d: this.getPath(data.map(d => ({ ...d, y: yStart })))
     };
 
     return (

--- a/src/RadialAreaChart/RadialAreaSeries/RadialLine.tsx
+++ b/src/RadialAreaChart/RadialAreaSeries/RadialLine.tsx
@@ -33,15 +33,16 @@ export class RadialLine extends Component<RadialLineProps> {
   }
 
   render() {
-    const { data, color, strokeWidth, animated, className } = this.props;
+    const { data, color, strokeWidth, animated, className, yScale } = this.props;
     const fill = color(data, 0);
 
     const enterProps = {
       d: this.getPath(data)
     };
 
+    const [yStart] = yScale.domain();
     const exitProps = {
-      d: this.getPath(data.map(d => ({ ...d, y: 0 })))
+      d: this.getPath(data.map(d => ({ ...d, y: yStart })))
     };
 
     return (

--- a/src/RadialBarChart/RadialBarSeries/PosedRadialBar.tsx
+++ b/src/RadialBarChart/RadialBarSeries/PosedRadialBar.tsx
@@ -1,13 +1,36 @@
 import posed from 'react-pose';
-import { transition } from '../../common/utils/animations';
+import {
+  transition,
+  VELOCITY,
+  DAMPING
+} from '../../common/utils/animations';
+import { spring } from 'popmotion';
+import { interpolate } from 'd3-interpolate';
+
+const pathTransition = props => {
+  const from = props.previousEnter ? props.previousEnter.y : props.from.y;
+  const interpolater = interpolate(from, props.to.y);
+
+  return spring({
+    from: 0,
+    to: 1,
+    velocity: VELOCITY,
+    damping: DAMPING
+  }).pipe(t => props.getArc({ ...props.to, y: interpolater(t) }));
+};
+
+const newTransition = {
+  ...transition,
+  d: pathTransition
+};
 
 export const PosedRadialBar = posed.path({
   enter: {
-    d: ({ enterProps }) => enterProps.d,
+    d: ({ enterProps }) => enterProps,
     delay: ({ animated, index, barCount }) => animated ? (index / barCount) * 500 : 0,
-    transition: ({ animated }) => (animated ? transition : { duration: 0 })
+    transition: ({ animated }) => (animated ? newTransition : { duration: 0 })
   },
   exit: {
-    d: ({ exitProps }) => exitProps.d
+    d: ({ exitProps }) => exitProps
   }
 });

--- a/src/RadialBarChart/RadialBarSeries/RadialBar.tsx
+++ b/src/RadialBarChart/RadialBarSeries/RadialBar.tsx
@@ -44,6 +44,7 @@ export class RadialBar extends Component<RadialBarProps, RadialBarState> {
 
   state: RadialBarState = {};
   ref = createRef<SVGPathElement>();
+  previousEnter: any;
 
   getFill(color: string) {
     const { id, gradient } = this.props;
@@ -95,9 +96,9 @@ export class RadialBar extends Component<RadialBarProps, RadialBarState> {
 
       const arcFn = arc()
         .innerRadius(innerRadius)
-        .outerRadius(() => outerRadius)
-        .startAngle(() => startAngle)
-        .endAngle(() => endAngle)
+        .outerRadius(outerRadius)
+        .startAngle(startAngle)
+        .endAngle(endAngle)
         .padAngle(0.01)
         .padRadius(innerRadius);
 
@@ -120,15 +121,20 @@ export class RadialBar extends Component<RadialBarProps, RadialBarState> {
   }
 
   renderBar(color: string) {
-    const { className, data, animated, barCount, index } = this.props;
+    const { className, data, animated, barCount, index, yScale } = this.props;
 
     const fill = this.getFill(color);
-    const enterProps = {
-      d: this.getArc(data)
-    };
+
+    // Track previous props
+    const previousEnter = this.previousEnter
+        ? { ...this.previousEnter }
+        : undefined;
+    this.previousEnter = { ...data };
+
+    const [yStart] = yScale.domain();
     const exitProps = {
-      // Setting y to 0 causes it to freak...
-      d: this.getArc({ ...data, y: .1 })
+      ...data,
+      y: yStart
     };
 
     return (
@@ -137,8 +143,10 @@ export class RadialBar extends Component<RadialBarProps, RadialBarState> {
         poseKey={`${data.x}-${data.y}`}
         ref={this.ref}
         animated={animated}
-        enterProps={enterProps}
+        enterProps={data}
+        previousEnter={previousEnter}
         exitProps={exitProps}
+        getArc={this.getArc.bind(this)}
         barCount={barCount}
         index={index}
         fill={fill}

--- a/src/RadialScatterPlot/RadialScatterSeries/RadialScatterPoint.tsx
+++ b/src/RadialScatterPlot/RadialScatterSeries/RadialScatterPoint.tsx
@@ -98,13 +98,15 @@ export class RadialScatterPoint extends Component<RadialScatterPointProps, Radia
   }
 
   render() {
-    const { size, data, color, index, animated, symbol, active, tooltip } = this.props;
+    const { size, data, color, index, animated, symbol, active, tooltip, yScale } = this.props;
     const { hovered } = this.state;
 
     const fill = isFunction(color) ? color(data, index) : color;
     const transform = this.getTranslate(data);
-    const exitTransform = this.getTranslate({ ...data, y: 0 });
     const sizeVal = typeof size === 'function' ? size(data) : size;
+
+    const [yStart] = yScale.domain();
+    const exitTransform = this.getTranslate({ ...data, y: yStart });
 
     return (
       <Fragment>

--- a/src/ScatterPlot/ScatterSeries/ScatterPoint.tsx
+++ b/src/ScatterPlot/ScatterSeries/ScatterPoint.tsx
@@ -89,10 +89,12 @@ export class ScatterPoint extends Component<
   }
 
   getCircleExit() {
-    const { xScale, data, height } = this.props;
+    const { xScale, data, yScale } = this.props;
+    const [yStartDomain] = yScale.domain();
+    const yPos = yScale(yStartDomain);
 
     return {
-      cy: height,
+      cy: yPos,
       cx: xScale(data.x)
     };
   }
@@ -112,9 +114,13 @@ export class ScatterPoint extends Component<
   }
 
   getSymbolExit() {
-    const { data, height, xScale } = this.props;
+    const { data, xScale, yScale } = this.props;
+
     const x = xScale(data.x);
-    const transform = `translate(${x}, ${height})`;
+    const [yStartDomain] = yScale.domain();
+    const yPos = yScale(yStartDomain);
+
+    const transform = `translate(${x}, ${yPos})`;
 
     return {
       transform

--- a/src/common/Axis/LinearAxis/LinearAxisTickSeries.tsx
+++ b/src/common/Axis/LinearAxis/LinearAxisTickSeries.tsx
@@ -9,7 +9,7 @@ import {
 } from './LinearAxisTickLine';
 import { formatValue } from '../../utils/formatting';
 import { getTextWidth } from '../../utils/width';
-import { getTicks } from '../../utils/ticks';
+import { getTicks, getMaxTicks } from '../../utils/ticks';
 import { TimeInterval } from 'd3-time';
 import { CloneElement } from '../../utils/children';
 
@@ -33,8 +33,7 @@ interface ProcessedTick {
 }
 
 export class LinearAxisTickSeries extends Component<
-  LinearAxisTickSeriesProps,
-  {}
+  LinearAxisTickSeriesProps
 > {
   static defaultProps: Partial<LinearAxisTickSeriesProps> = {
     line: <LinearAxisTickLine />,
@@ -157,7 +156,8 @@ export class LinearAxisTickSeries extends Component<
   getTicks(): ProcessedTick[] {
     const { scale, tickSize, tickValues, interval } = this.props;
     const dimension = this.getDimension();
-    const ticks = getTicks(scale, tickSize, tickValues, dimension, interval);
+    const maxTicks = getMaxTicks(tickSize, dimension);
+    const ticks = getTicks(scale, tickValues, maxTicks, interval);
     const adjustedScale = this.getAdjustedScale();
     const format = this.getLabelFormat();
     const result: ProcessedTick[] = [];

--- a/src/common/Axis/RadialAxis/RadialAxisTickSeries/RadialAxisTickSeries.tsx
+++ b/src/common/Axis/RadialAxis/RadialAxisTickSeries/RadialAxisTickSeries.tsx
@@ -1,11 +1,14 @@
 import React, { Component, Fragment } from 'react';
 import { RadialAxisTick, RadialAxisTickProps } from './RadialAxisTick';
 import { CloneElement } from '../../../utils/children';
-import { reduceTicks } from '../../../utils/ticks';
+import { getTicks } from '../../../utils/ticks';
+import { TimeInterval } from 'd3-time';
 
 export interface RadialAxisTickSeriesProps {
   scale: any;
-  count: number;
+  count?: number;
+  interval?: number | TimeInterval;
+  tickValues: any[];
   outerRadius: number;
   innerRadius: number;
   tick: JSX.Element;
@@ -17,18 +20,9 @@ export class RadialAxisTickSeries extends Component<RadialAxisTickSeriesProps> {
     tick: <RadialAxisTick />
   };
 
-  getTicks(scale, count: number) {
-    if (scale.ticks) {
-      return scale.ticks.apply(scale, [count]);
-    } else {
-      const tickValues = scale.domain();
-      return reduceTicks(tickValues, count);
-    }
-  }
-
   render() {
-    const { scale, count, outerRadius, tick, innerRadius } = this.props;
-    const ticks = this.getTicks(scale, count);
+    const { scale, count, outerRadius, tick, tickValues, innerRadius, interval } = this.props;
+    const ticks = getTicks(scale, tickValues, count, interval);
 
     return (
       <Fragment>

--- a/src/common/Gridline/GridlineSeries.tsx
+++ b/src/common/Gridline/GridlineSeries.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment, Component } from 'react';
 import { Gridline, GridlineProps } from './Gridline';
-import { getTicks } from '../utils/ticks';
+import { getTicks, getMaxTicks } from '../utils/ticks';
 import { CloneElement } from '../utils/children';
 import { LinearAxisProps } from '../Axis';
 import { GridStripeProps } from './GridStripe';
@@ -28,16 +28,14 @@ export class GridlineSeries extends Component<GridlineSeriesProps, {}> {
     return {
       yAxisGrid: getTicks(
         yScale,
-        yAxis.tickSeries.props.tickSize,
         yAxis.tickSeries.props.tickValues,
-        height,
+        getMaxTicks(yAxis.tickSeries.props.tickSize, height),
         yAxis.tickSeries.props.interval
       ),
       xAxisGrid: getTicks(
         xScale,
-        xAxis.tickSeries.props.tickSize,
         xAxis.tickSeries.props.tickValues,
-        width,
+        getMaxTicks(xAxis.tickSeries.props.tickSize, width),
         xAxis.tickSeries.props.interval
       )
     };

--- a/src/common/utils/ticks.tsx
+++ b/src/common/utils/ticks.tsx
@@ -32,9 +32,8 @@ export function getMaxTicks(size: number, dimension: number) {
  */
 export function getTicks(
   scale: any,
-  tickSize: number,
   tickValues: any[],
-  dimension: number,
+  maxTicks = 100,
   interval?: number | TimeInterval
 ) {
   let result;
@@ -42,7 +41,6 @@ export function getTicks(
   if (tickValues) {
     result = tickValues;
   } else {
-    const maxTicks = getMaxTicks(tickSize, dimension);
 
     if (scale.ticks) {
       if (interval) {


### PR DESCRIPTION
This PR:

- Implements custom tweening for radial bar chart because of errors
- Abstracts tick methods and uses in radial axis
- Updates radial bar to use start domain vs 0
- Updates radial line/area to use start domain vs 0
- Updates radial scatter to use start domain vs 0
- Updates linear to use start domain vs 0
- Adds ability to specify tick values and intervals in radial axis

NOTE: There is a error getting thrown from pose that is likely a bug in that lib. Will log bug: `Error: <path> attribute d: Expected moveto path command ('M' or 'm'), "[object Object]".`
