### PR TITLE
Fix Sankey's onClick + Upgraded node-sass to 4.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "reaviz",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9730,22 +9730,10 @@
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.11.tgz",
       "integrity": "sha512-DHb1ub+rMjjrxqlB3H56/6MXtm1lSksDp2rA2cNWjG8mlDUYFhUj3Di2Zn5IwSU87xLv8tNIQ7sSwE/YOX/D/Q=="
     },
-    "lodash.assign": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
-      "dev": true
-    },
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
-      "dev": true
-    },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
     "lodash.debounce": {
@@ -10357,7 +10345,8 @@
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
       "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -10550,9 +10539,9 @@
       }
     },
     "node-sass": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.11.0.tgz",
-      "integrity": "sha512-bHUdHTphgQJZaF1LASx0kAviPH7sGlcyNhWade4eVIpFp6tsn7SV8xNMTbsQFpEV9VXpnwTTnNYlfsZXgGgmkA==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.12.0.tgz",
+      "integrity": "sha512-A1Iv4oN+Iel6EPv77/HddXErL2a+gZ4uBeZUy+a8O35CFYTXhgA8MgLCWBtwpGZdCvTvQ9d+bQxX/QC36GDPpQ==",
       "dev": true,
       "requires": {
         "async-foreach": "^0.1.3",
@@ -10562,12 +10551,10 @@
         "get-stdin": "^4.0.1",
         "glob": "^7.0.3",
         "in-publish": "^2.0.0",
-        "lodash.assign": "^4.2.0",
-        "lodash.clonedeep": "^4.3.2",
-        "lodash.mergewith": "^4.6.0",
+        "lodash": "^4.17.11",
         "meow": "^3.7.0",
         "mkdirp": "^0.5.1",
-        "nan": "^2.10.0",
+        "nan": "^2.13.2",
         "node-gyp": "^3.8.0",
         "npmlog": "^4.0.0",
         "request": "^2.88.0",
@@ -10604,6 +10591,12 @@
             "lru-cache": "^4.0.1",
             "which": "^1.2.9"
           }
+        },
+        "nan": {
+          "version": "2.13.2",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+          "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+          "dev": true
         },
         "supports-color": {
           "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "jest": "^24.1.0",
     "jest-junit": "^6.3.0",
     "moment": "^2.24.0",
-    "node-sass": "^4.11.0",
+    "node-sass": "^4.12.0",
     "postcss-focus-visible": "^4.0.0",
     "react": "^16.8.4",
     "react-docgen-typescript-loader": "^3.0.1",

--- a/src/Sankey/Sankey.story.tsx
+++ b/src/Sankey/Sankey.story.tsx
@@ -29,6 +29,8 @@ const colorScheme = chroma
   .mode('lch')
   .colors(sankeyNodes.length);
 
+const onNodeClick = (title: string) => window.alert(`${title} is clicked`);
+
 storiesOf('Charts/Sankey', module)
   .add('Simple', () => (
     <Sankey
@@ -36,7 +38,11 @@ storiesOf('Charts/Sankey', module)
       height={300}
       width={500}
       nodes={simpleSankeyNodes.map((node, i) => (
-        <SankeyNode key={`node-${i}`} {...node} />
+        <SankeyNode
+          key={`node-${i}`}
+          {...node}
+          onClick={() => onNodeClick(node.title)}
+        />
       ))}
       links={simpleSankeyLinks.map((link, i) => (
         <SankeyLink key={`link-${i}`} {...link} />

--- a/src/Sankey/Sankey.tsx
+++ b/src/Sankey/Sankey.tsx
@@ -105,15 +105,20 @@ export class Sankey extends Component<SankeyProps, SankeyState> {
     this.setState({ activeNodes: [], activeLinks: [] });
   }
 
-  renderNode(computedNode: Node, index: number, chartWidth: number) {
-    const { animated, nodes } = this.props;
+  renderNode(
+    computedNode: Node,
+    node: JSX.Element,
+    index: number,
+    chartWidth: number
+  ) {
+    const { animated } = this.props;
     const { activeNodes } = this.state;
     const active = activeNodes.some(node => node.index === computedNode.index);
     const disabled = activeNodes.length > 0 && !active;
 
     return (
       <CloneElement<SankeyNodeProps>
-        element={nodes[index]}
+        element={node}
         key={`node-${index}`}
         active={active}
         animated={animated}
@@ -127,6 +132,11 @@ export class Sankey extends Component<SankeyProps, SankeyState> {
   }
 
   renderNodes(nodes: Node[], chartWidth: number) {
+    const nodeMap = new Map<string, JSX.Element>();
+    this.props.nodes.forEach(
+      node => node && nodeMap.set(node.props.title, node)
+    );
+
     nodes.sort((a, b) => {
       const aX0 = a && a.x0 ? a.x0 : 0;
       const aY0 = a && a.y0 ? a.y0 : 0;
@@ -138,7 +148,9 @@ export class Sankey extends Component<SankeyProps, SankeyState> {
 
     return (
       <Fragment>
-        {nodes.map((node, index) => this.renderNode(node, index, chartWidth))}
+        {nodes.map((node, index) =>
+          this.renderNode(node, nodeMap.get(node.title), index, chartWidth)
+        )}
       </Fragment>
     );
   }


### PR DESCRIPTION
Fixed the issue #52.

Additionally added an onClick example to Sankey's Simple story.

NOTE: Since node-sass v4.11.0 doesn't work with node v12.2.0, this PR also upgraded node-sass to the latest version (v4.12.0).