### PR TITLE
Redo Zooming and Panning

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -18,3 +18,5 @@
     color: #000;
   }
 </style>
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0"/>
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -15202,6 +15202,11 @@
         "punycode": "^2.1.0"
       }
     },
+    "transformation-matrix": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/transformation-matrix/-/transformation-matrix-2.0.2.tgz",
+      "integrity": "sha512-4SzAEBeqsL9J8w5Bsi9W36aXh1Bep9lW/NSLxT9F8PMj+LG/nQAiViKSvTjJ6V4jDO520cSBGvr80QZNlKLJ/w=="
+    },
     "trim": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12706,11 +12706,6 @@
       "resolved": "https://registry.npmjs.org/react-node-resolver/-/react-node-resolver-2.0.1.tgz",
       "integrity": "sha512-+PPy/FtAAo5wsLQYMlHkxJ3AMUGL33gpEIx/HBzS8OrcIfacRhGaNVWUJ8bhEbc64en+/bbCNTVZR+pkhqXEbA=="
     },
-    "react-pan-and-zoom-hoc": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/react-pan-and-zoom-hoc/-/react-pan-and-zoom-hoc-2.0.1.tgz",
-      "integrity": "sha512-BqGOwlVr0QjrhaAsVsxXkZ0NoIeREaiDETdZMgXmFWrpYnS25fFc8+vuVKvMISzHLRM/9azkz0A/BgL64PdOpA=="
-    },
     "react-popper": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12706,6 +12706,11 @@
       "resolved": "https://registry.npmjs.org/react-node-resolver/-/react-node-resolver-2.0.1.tgz",
       "integrity": "sha512-+PPy/FtAAo5wsLQYMlHkxJ3AMUGL33gpEIx/HBzS8OrcIfacRhGaNVWUJ8bhEbc64en+/bbCNTVZR+pkhqXEbA=="
     },
+    "react-pan-and-zoom-hoc": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/react-pan-and-zoom-hoc/-/react-pan-and-zoom-hoc-2.0.1.tgz",
+      "integrity": "sha512-BqGOwlVr0QjrhaAsVsxXkZ0NoIeREaiDETdZMgXmFWrpYnS25fFc8+vuVKvMISzHLRM/9azkz0A/BgL64PdOpA=="
+    },
     "react-popper": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.3.tgz",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "react-sizeme": "^2.5.2",
     "react-transition-group": "^2.5.3",
     "topojson-client": "^3.0.0",
+    "transformation-matrix": "^2.0.2",
     "world-atlas": "^1.1.4"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "popper.js": "^1.14.7",
     "rdk": "^1.0.2",
     "react-countup": "^4.1.2",
-    "react-pan-and-zoom-hoc": "^2.0.1",
     "react-pose": "^4.0.8",
     "react-scrolllock": "^4.0.1",
     "react-sizeme": "^2.5.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.1.0",
   "description": "Data Visualization using React and D3.js",
   "scripts": {
-    "start": "start-storybook",
+    "start": "start-storybook -p 9010",
     "build-storybook": "build-storybook",
     "deploy-storybook": "gh-pages -d storybook-static",
     "build": "rollup -c",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "popper.js": "^1.14.7",
     "rdk": "^1.0.2",
     "react-countup": "^4.1.2",
+    "react-pan-and-zoom-hoc": "^2.0.1",
     "react-pose": "^4.0.8",
     "react-scrolllock": "^4.0.1",
     "react-sizeme": "^2.5.2",

--- a/src/common/Brush/BrushHandle.tsx
+++ b/src/common/Brush/BrushHandle.tsx
@@ -2,8 +2,8 @@ import React, { Component } from 'react';
 import bind from 'memoize-bind';
 import classNames from 'classnames';
 import { range } from 'd3-array';
-import { Pan, PanMoveEvent } from '../Gestures/Pan';
 import * as css from './BrushHandle.module.scss';
+import { toggleTextSelection } from '../utils/selection';
 
 interface BrushHandleProps {
   height: number;
@@ -19,53 +19,84 @@ export class BrushHandle extends Component<BrushHandleProps, BrushHandleState> {
     isDragging: false
   };
 
-  onPanStart() {
+  componentWillUnmount() {
+    this.disposeHandlers();
+  }
+
+  disposeHandlers() {
+    window.removeEventListener('mousemove', this.onMouseMove);
+    window.removeEventListener('mouseup', this.onMouseUp);
+
+    // Reset cursor on body back to original
+    document.body.style['cursor'] = 'inherit';
+    toggleTextSelection(true);
+  }
+
+  onMouseDown(event: React.MouseEvent) {
+    // Ignore right click
+    if (event.nativeEvent.which === 3) {
+      return;
+    }
+
+    event.stopPropagation();
+    event.preventDefault();
+
     this.setState({
       isDragging: true
     });
+
+    // Always bind event so we cancel movement even if no action was taken
+    window.addEventListener('mousemove', this.onMouseMove);
+    window.addEventListener('mouseup', this.onMouseUp);
   }
 
-  onPanMove(event: PanMoveEvent) {
-    this.props.onHandleDrag(event.deltaX);
-  }
+  onMouseMove = (event) => {
+    if (!this.state.isDragging) {
+      return;
+    }
 
-  onPanEnd() {
+    event.preventDefault();
+    event.stopPropagation();
+    toggleTextSelection(false);
+    document.body.style['cursor'] = 'ew-resize';
+
+    this.props.onHandleDrag(event.movementX);
+  };
+
+  onMouseUp = () => {
+    this.disposeHandlers();
+
     this.setState({
       isDragging: false
     });
-  }
+  };
 
   render() {
     const { height } = this.props;
     const { isDragging } = this.state;
 
     return (
-      <Pan
-        onPanStart={bind(this.onPanStart, this)}
-        onPanMove={bind(this.onPanMove, this)}
-        onPanEnd={bind(this.onPanEnd, this)}
-        cursor="ew-resize"
+      <g
+        onMouseDown={bind(this.onMouseDown, this)}
       >
-        <g>
-          <line className={css.line} y1="0" y2={height} x1="5" x2="5" />
-          <rect
-            className={classNames(css.handle, { [css.dragging]: isDragging })}
-            height={height - 10}
-            style={{ cursor: 'ew-resize' }}
-            width={8}
-            y="5"
-            y1={height - 5}
-          />
-          <g
-            transform={`translate(-1, ${height / 2 - 10})`}
-            style={{ pointerEvents: 'none' }}
-          >
-            {range(5).map(i => (
-              <circle cy={i * 5} cx="5" r=".5" key={i} className={css.dot} />
-            ))}
-          </g>
+        <line className={css.line} y1="0" y2={height} x1="5" x2="5" />
+        <rect
+          className={classNames(css.handle, { [css.dragging]: isDragging })}
+          height={height - 10}
+          style={{ cursor: 'ew-resize' }}
+          width={8}
+          y="5"
+          y1={height - 5}
+        />
+        <g
+          transform={`translate(-1, ${height / 2 - 10})`}
+          style={{ pointerEvents: 'none' }}
+        >
+          {range(5).map(i => (
+            <circle cy={i * 5} cx="5" r=".5" key={i} className={css.dot} />
+          ))}
         </g>
-      </Pan>
+      </g>
     );
   }
 }

--- a/src/common/Gestures/Pan.tsx
+++ b/src/common/Gestures/Pan.tsx
@@ -7,10 +7,10 @@ interface PanProps {
   disabled: boolean;
   threshold: number;
   cursor?: string;
-  offsetX: number;
+  x: number;
+  y: number;
   scale: number;
   matrix: any;
-  offsetY: number;
   width: number;
   height: number;
   constrain: boolean;
@@ -27,9 +27,10 @@ export interface PanStartEvent {
 
 export interface PanMoveEvent {
   source: 'mouse' | 'touch';
-  deltaX: number;
-  deltaY: number;
+  x: number;
+  y: number;
   nativeEvent: MouseEvent | TouchEvent;
+  matrix: any;
 }
 
 export interface PanEndEvent {
@@ -44,8 +45,8 @@ export interface PanCancelEvent {
 
 export class Pan extends Component<PanProps> {
   static defaultProps: Partial<PanProps> = {
-    offsetX: 0,
-    offsetY: 0,
+    x: 0,
+    y: 0,
     disabled: false,
     scale: 1,
     threshold: 10,
@@ -72,7 +73,6 @@ export class Pan extends Component<PanProps> {
     if (!this.updating) {
       this.matrix = fromObject(this.props.matrix);
       this.updating = false;
-      console.log('updating pan...')
     }
   }
 
@@ -92,9 +92,10 @@ export class Pan extends Component<PanProps> {
   }
 
   checkThreshold() {
+    const { threshold } = this.props;
     return !this.started &&
-      ((Math.abs(this.deltaX) > this.props.threshold) ||
-        (Math.abs(this.deltaY) > this.props.threshold));
+      ((Math.abs(this.deltaX) > threshold) ||
+        (Math.abs(this.deltaY) > threshold));
   }
 
   pan(x: number, y: number, nativeEvent, source: 'mouse' | 'touch') {
@@ -113,10 +114,10 @@ export class Pan extends Component<PanProps> {
         this.props.onPanMove({
           source,
           nativeEvent,
-          offsetX: matrix.e,
-          offsetY: matrix.f,
-          matrix: matrix
-        } as any);
+          x: matrix.e,
+          y: matrix.f,
+          matrix
+        });
       }
     });
   }
@@ -234,8 +235,9 @@ export class Pan extends Component<PanProps> {
       this.props.onPanMove({
         source: 'touch',
         nativeEvent: event,
-        deltaX: x,
-        deltaY: y
+        x,
+        y,
+        matrix: null
       });
     }
 

--- a/src/common/Gestures/Pan.tsx
+++ b/src/common/Gestures/Pan.tsx
@@ -165,7 +165,7 @@ export class Pan extends Component<PanProps> {
   pan(x: number, y: number, nativeEvent, source: 'mouse' | 'touch') {
     const { scale, constrain, width, height, matrix } = this.props;
 
-    let newMatrix = smoothMatrix(transform(
+    const newMatrix = smoothMatrix(transform(
       matrix,
       translate(x / scale, y / scale)
     ), 100);
@@ -174,6 +174,8 @@ export class Pan extends Component<PanProps> {
     if (!shouldConstrain) {
       this.onPanMove(newMatrix.e, newMatrix.f, source, nativeEvent);
     }
+
+    return shouldConstrain;
   }
 
   onMouseDown(event: React.MouseEvent) {
@@ -273,21 +275,15 @@ export class Pan extends Component<PanProps> {
       this.deltaY = 0;
       this.started = true;
 
-      this.props.onPanStart({
-        nativeEvent: event,
-        source: 'touch'
-      });
+      this.onPanStart(event, 'touch');
     } else {
-      this.props.onPanMove({
-        source: 'touch',
-        nativeEvent: event,
-        x,
-        y
-      });
-    }
+      const contrained = this.pan(deltaX, deltaY, event, 'touch');
 
-    this.prevXPosition = x;
-    this.prevYPosition = y;
+      if (!contrained) {
+        this.prevXPosition = x;
+        this.prevYPosition = y;
+      }
+    }
   };
 
   onTouchEnd = (event: TouchEvent) => {

--- a/src/common/Gestures/Pan.tsx
+++ b/src/common/Gestures/Pan.tsx
@@ -56,18 +56,19 @@ export class Pan extends Component<PanProps> {
   started: boolean = false;
   deltaX: number = 0;
   deltaY: number = 0;
-  transformationMatrix = identity();
+  matrix: any;
   updating = false;
 
   constructor(props: PanProps) {
     super(props);
-    this.transformationMatrix = fromObject(props.matrix);
+    this.matrix = fromObject(props.matrix);
   }
 
   componentDidUpdate() {
     if (!this.updating) {
-      this.transformationMatrix = fromObject(this.props.matrix);
+      this.matrix = fromObject(this.props.matrix);
       this.updating = false;
+      console.log('updating pan...')
     }
   }
 
@@ -98,20 +99,17 @@ export class Pan extends Component<PanProps> {
     requestAnimationFrame(() => {
       const curScale = this.props.scale;
 
-      this.transformationMatrix = transform(
-        this.transformationMatrix,
+      this.matrix = smoothMatrix(transform(
+        this.matrix,
         translate(x / curScale, y / curScale)
-      );
-
-      // Clone the object before sending up
-      const result = fromObject(smoothMatrix(this.transformationMatrix, 100));
+      ), 100);
 
       this.props.onPanMove({
         source,
         nativeEvent,
-        offsetX: result.e,
-        offsetY: result.f,
-        matrix: result
+        offsetX: this.matrix.e,
+        offsetY: this.matrix.f,
+        matrix: this.matrix
       } as any);
     });
   }

--- a/src/common/Gestures/Zoom.tsx
+++ b/src/common/Gestures/Zoom.tsx
@@ -22,7 +22,6 @@ export interface ZoomEvent {
   scale: number;
   x: number;
   y: number;
-  matrix: any;
 }
 
 export class Zoom extends Component<ZoomGestureProps> {
@@ -83,18 +82,19 @@ export class Zoom extends Component<ZoomGestureProps> {
         onZoom({
           scale: newMatrix.a,
           x: newMatrix.e,
-          y: newMatrix.f,
-          matrix: newMatrix
+          y: newMatrix.f
         });
       });
     }
   }
 
   onWheel(event: MouseWheelEvent) {
-    event.preventDefault();
-    const { x, y } = getPointFromMatrix(event, this.props.matrix);
-    const step = this.getStep(event.deltaY);
-    this.scale(x, y, step);
+    if (!this.props.disableMouseWheel) {
+      event.preventDefault();
+      const { x, y } = getPointFromMatrix(event, this.props.matrix);
+      const step = this.getStep(event.deltaY);
+      this.scale(x, y, step);
+    }
   }
 
   onTouchStart = (event: TouchEvent) => {

--- a/src/common/Gestures/Zoom.tsx
+++ b/src/common/Gestures/Zoom.tsx
@@ -11,8 +11,8 @@ interface ZoomGestureProps {
   scaleFactor: number;
   scale: number;
   matrix: any;
-  offsetX: number;
-  offsetY: number;
+  x: number;
+  y: number;
   width: number;
   height: number;
   constrain: boolean;
@@ -23,14 +23,15 @@ interface ZoomGestureProps {
 
 export interface ZoomEvent {
   scale: number;
-  offsetX: number;
-  offsetY: number;
+  x: number;
+  y: number;
+  matrix: any;
 }
 
 export class Zoom extends Component<ZoomGestureProps> {
   static defaultProps: Partial<ZoomGestureProps> = {
-    offsetX: 0,
-    offsetY: 0,
+    x: 0,
+    y: 0,
     scale: 1,
     scaleFactor: 0.1,
     minZoom: 1,
@@ -105,11 +106,7 @@ export class Zoom extends Component<ZoomGestureProps> {
       const delta = distance - this.lastDistance;
       const step = this.getStep(-delta);
 
-      this.scale({
-        step,
-        x: this.firstMidpoint.x,
-        y: this.firstMidpoint.y
-      });
+      this.scale(this.firstMidpoint.x, this.firstMidpoint.y, step);
 
       this.lastDistance = distance;
     }
@@ -126,14 +123,14 @@ export class Zoom extends Component<ZoomGestureProps> {
     this.props.onZoomEnd();
   };
 
-  onWheel(event) {
+  onWheel(event: MouseWheelEvent) {
     event.preventDefault();
-    const point = getPointFromMatrix(event, this.matrix);
+    const { x, y } = getPointFromMatrix(event, this.matrix);
     const step = this.getStep(event.deltaY);
-    this.scale({ step, ...point });
+    this.scale(x, y, step);
   }
 
-  scale({ step, x, y }) {
+  scale(x: number, y: number, step: number) {
     const { minZoom, maxZoom, onZoom, constrain, height, width } = this.props;
 
     let zoomLevel = Math.min(this.matrix.a, maxZoom);
@@ -155,10 +152,10 @@ export class Zoom extends Component<ZoomGestureProps> {
 
           onZoom({
             scale: this.matrix.a,
-            offsetX: this.matrix.e,
-            offsetY: this.matrix.f,
+            x: this.matrix.e,
+            y: this.matrix.f,
             matrix: this.matrix
-          } as any);
+          });
 
           clearTimeout(this.timeout);
           this.timeout = setTimeout(() => this.updating = false, 100);

--- a/src/common/Gestures/Zoom.tsx
+++ b/src/common/Gestures/Zoom.tsx
@@ -1,8 +1,8 @@
 import React, { Component, createRef } from 'react';
 import { toggleTextSelection } from '../utils/selection';
-import { getPointFromTouch, getPointFromMatrix, constrainMatrix, isZoomLevelGoingOutOfBounds } from '../utils/position';
+import { getPointFromTouch, getPointFromMatrix, isZoomLevelGoingOutOfBounds } from '../utils/position';
 import { getDistanceBetweenPoints, getMidpoint } from './pinchUtils';
-import { scale, smoothMatrix, transform, translate, fromObject, applyToPoint } from 'transformation-matrix';
+import { scale, smoothMatrix, transform, translate } from 'transformation-matrix';
 
 interface ZoomGestureProps {
   disabled?: boolean;
@@ -13,9 +13,6 @@ interface ZoomGestureProps {
   matrix: any;
   x: number;
   y: number;
-  width: number;
-  height: number;
-  constrain: boolean;
   disableMouseWheel?: boolean;
   onZoom: (event: ZoomEvent) => void;
   onZoomEnd: () => void;
@@ -66,7 +63,7 @@ export class Zoom extends Component<ZoomGestureProps> {
   }
 
   scale(x: number, y: number, step: number) {
-    const { minZoom, maxZoom, onZoom, constrain, height, width, matrix } = this.props;
+    const { minZoom, maxZoom, onZoom, matrix } = this.props;
 
     const outside = isZoomLevelGoingOutOfBounds({
       d: matrix.a,
@@ -82,30 +79,14 @@ export class Zoom extends Component<ZoomGestureProps> {
         translate(-x, -y)
       ), 100);
 
-      const shouldConstrain = constrain && constrainMatrix(height, width, newMatrix);
-
-      if (!shouldConstrain) {
-        requestAnimationFrame(() => {
-          onZoom({
-            scale: newMatrix.a,
-            x: newMatrix.e,
-            y: newMatrix.f,
-            matrix: newMatrix
-          });
+      requestAnimationFrame(() => {
+        onZoom({
+          scale: newMatrix.a,
+          x: newMatrix.e,
+          y: newMatrix.f,
+          matrix: newMatrix
         });
-      } else {
-        // TODO: not 100% but close!
-        requestAnimationFrame(() => {
-          const point = applyToPoint(newMatrix, { x: 0, y: 0 });
-
-          onZoom({
-            scale: newMatrix.d,
-            x: point.x,
-            y: point.y,
-            matrix: matrix
-          });
-        });
-      }
+      });
     }
   }
 

--- a/src/common/Gestures/Zoom.tsx
+++ b/src/common/Gestures/Zoom.tsx
@@ -64,7 +64,6 @@ export class Zoom extends Component<ZoomGestureProps> {
     if (!this.updating) {
       this.matrix = fromObject(this.props.matrix);
       this.updating = false;
-      console.log('updating zoom...')
     }
   }
 

--- a/src/common/Gestures/Zoom.tsx
+++ b/src/common/Gestures/Zoom.tsx
@@ -1,291 +1,306 @@
-import * as React from 'react';
-import * as ReactDOM from 'react-dom';
+import React, { Component, createRef } from 'react';
+import { toggleTextSelection } from '../utils/selection';
+import { getPointFromTouch, getPositionForTarget } from '../utils/position';
+import { getDistanceBetweenPoints, between, getMidpoint } from './pinchUtils';
+import ReactDOM from 'react-dom';
 
-export type Overwrite<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U;
-
-export interface PanAndZoomHOCProps {
-    x?: number;
-    y?: number;
-    scale?: number;
-    scaleFactor?: number;
-    minScale?: number;
-    maxScale?: number;
-    renderOnChange?: boolean;
-    passOnProps?: boolean;
-    ignorePanOutside?: boolean;
-    disableScrollZoom?: boolean;
-    onPanStart?: (event: MouseEvent | TouchEvent) => void;
-    onPanMove?: (x: number, y: number, event: MouseEvent | TouchEvent) => void;
-    onPanEnd?: (x: number, y: number, event: MouseEvent | TouchEvent) => void;
-    onZoom?: (x: number | undefined, y: number | undefined, scale: number | undefined, event: WheelEvent) => void;
-    onPanAndZoom?: (x: number, y: number, scale: number, event: WheelEvent) => void;
+interface ZoomGestureProps {
+  disabled?: boolean;
+  maxZoom: number;
+  minZoom: number;
+  scaleFactor: number;
+  scale: number;
+  offsetX: number;
+  offsetY: number;
+  disableMouseWheel?: boolean;
+  onZoom: (event: ZoomEvent) => void;
+  onZoomEnd: () => void;
 }
 
-export function panAndZoom<P>(WrappedComponent: React.SFC<P> | React.ComponentClass<P> | string): React.ComponentClass<Overwrite<P, PanAndZoomHOCProps>> {
-    return class PanAndZoomHOC extends React.PureComponent<PanAndZoomHOCProps, never> {
-        /*
-        static propTypes = {
-            x: PropTypes.number,
-            y: PropTypes.number,
-            scale: PropTypes.number,
-            scaleFactor: PropTypes.number,
-            minScale: PropTypes.number,
-            maxScale: PropTypes.number,
-            renderOnChange: PropTypes.bool,
-            passOnProps: PropTypes.bool,
-            ignorePanOutside: PropTypes.bool,
-            disableScrollZoom: PropTypes.bool,
-            onPanStart: PropTypes.func,
-            onPanMove: PropTypes.func,
-            onPanEnd: PropTypes.func,
-            onZoom: PropTypes.func,
-            onPanAndZoom: PropTypes.func
-        };
-        */
+export interface ZoomEvent {
+  scale: number;
+  offsetX: number;
+  offsetY: number;
+}
 
-        static defaultProps = {
-            x: 0.5,
-            y: 0.5,
-            scale: 1,
-            scaleFactor: Math.sqrt(2),
-            minScale: Number.EPSILON,
-            maxScale: Number.POSITIVE_INFINITY,
-            renderOnChange: false,
-            passOnProps: false
-        };
+export class Zoom extends Component<ZoomGestureProps> {
+  static defaultProps: Partial<ZoomGestureProps> = {
+    offsetX: 0.5,
+    offsetY: 0.5,
+    scale: 1,
+    scaleFactor: 0.2,
+    minZoom: 1, // Number.EPSILON,
+    maxZoom: 10 //Number.POSITIVE_INFINITY,
+  }
 
-        dx: number = 0;
-        dy: number = 0;
-        ds: number = 0;
-        element: Element | null = null;
 
-        componentWillReceiveProps(nextProps: PanAndZoomHOCProps) {
-            if (this.props.x !== nextProps.x || this.props.y !== nextProps.y) {
-                this.dx = 0;
-                this.dy = 0;
-            }
-            if (this.props.scale !== nextProps.scale) {
-                this.ds = 0;
-            }
+  lastDistance: any;
+  firstMidpoint: any;
+  timeout: any;
+  childRef = createRef<SVGGElement>();
+
+  componentDidMount() {
+    if (!this.props.disabled) {
+      // Manually bind due to pinch issues not being prevented
+      // https://github.com/facebook/react/issues/9809
+      if (this.childRef.current) {
+        this.childRef.current.addEventListener('touchstart', this.onTouchStart);
+      }
+    }
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('touchstart', this.onTouchStart);
+    window.removeEventListener('touchmove', this.onTouchMove);
+    window.removeEventListener('touchend', this.onTouchEnd);
+    toggleTextSelection(true);
+  }
+
+  onTouchStart = (event: TouchEvent) => {
+    if (event.touches.length === 2 && this.childRef.current) {
+      event.preventDefault();
+      event.stopPropagation();
+      toggleTextSelection(false);
+
+      const pointA = getPointFromTouch(event.touches[0], this.childRef.current);
+      const pointB = getPointFromTouch(event.touches[1], this.childRef.current);
+      this.lastDistance = getDistanceBetweenPoints(pointA, pointB);
+      this.firstMidpoint = getMidpoint(pointA, pointB);
+
+      window.addEventListener('touchmove', this.onTouchMove);
+      window.addEventListener('touchend', this.onTouchEnd);
+    }
+  };
+
+  onTouchMove = (event: TouchEvent) => {
+    if (event.touches.length === 2 && this.childRef.current) {
+      event.preventDefault();
+      event.stopPropagation();
+
+      const pointA = getPointFromTouch(event.touches[0], this.childRef.current);
+      const pointB = getPointFromTouch(event.touches[1], this.childRef.current);
+      const distance = getDistanceBetweenPoints(pointA, pointB);
+
+      const { maxZoom, scaleFactor, offsetX, offsetY, scale, minZoom } = this.props;
+      const delta = distance - this.lastDistance;
+      const ratio = Math.exp((delta / 30) * scaleFactor);
+      const newScale = between(1, maxZoom, scale * ratio);
+
+      if (newScale <= minZoom) {
+        return;
+      }
+
+      const newOffsetX = Math.min(
+        (offsetX - this.firstMidpoint.x) * ratio + this.firstMidpoint.x,
+        0
+      );
+
+      const newOffsetY = Math.min(
+        (offsetY - this.firstMidpoint.y) * ratio + this.firstMidpoint.y,
+        0
+      );
+
+      if (scale < this.props.maxZoom) {
+        this.props.onZoom({
+          scale: newScale,
+          offsetX: newOffsetX,
+          offsetY: newOffsetY
+        });
+      }
+
+      this.lastDistance = distance;
+    }
+  };
+
+  onTouchEnd = (event: TouchEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    window.removeEventListener('touchmove', this.onTouchMove);
+    window.removeEventListener('touchend', this.onTouchEnd);
+
+    toggleTextSelection(true);
+    this.props.onZoomEnd();
+  };
+
+    /*
+  onWheel(event: React.MouseEvent) {
+    const {
+      disabled,
+      maxZoom,
+      zoomStep,
+      scale,
+      offsetX,
+      offsetY,
+      onZoomEnd,
+      disableMouseWheel,
+      minZoom
+    } = this.props;
+
+    if (!disabled && !disableMouseWheel) {
+      const nativeEvent = event.nativeEvent as WheelEvent;
+      const position = this.getNewPosition();
+
+      const positions = getPositionForTarget(nativeEvent);
+      const wheel = (nativeEvent.deltaY / 120) * -1;
+      const ratio = Math.exp(wheel * zoomStep);
+      const roundedScale = Math.ceil(scale * ratio);
+      const inBounds = roundedScale <= maxZoom && roundedScale >= minZoom;
+
+      console.log('here', roundedScale);
+
+      if (inBounds && roundedScale !== scale) {
+        // nativeEvent.preventDefault();
+
+        const newScale = between(minZoom, maxZoom, scale * ratio);
+
+
+        const newOffsetX = Math.min(
+          (offsetX - positions.x) * ratio + positions.x,
+          0
+        );
+
+        const newOffsetY = Math.min(
+          (offsetY - positions.y) * ratio + positions.y,
+          0
+        );
+
+        this.props.onZoom({
+          scale: newScale,
+          offsetX: newOffsetX,
+          offsetY: newOffsetY
+        });
+
+        clearTimeout(this.timeout);
+        this.timeout = setTimeout(() => {
+          onZoomEnd();
+        }, 500);
+      }
+    }
+  }
+
+    disabled?: boolean;
+  maxZoom: number;
+  minZoom: number;
+  zoomStep: number;
+  scale: number;
+  offsetX: number;
+  offsetY: number;
+  disableMouseWheel?: boolean;
+  onZoom: (event: ZoomEvent) => void;
+  onZoomEnd: () => void;
+
+    */
+
+
+  onWheel(event: WheelEvent) {
+    event.preventDefault()
+    const { minZoom, maxZoom } = this.props
+    let { scale, offsetX, offsetY, scaleFactor } = this.props
+
+    // Keep the previous zoom value
+    const prevZoom = scale
+
+    // Determine if we are increasing or decreasing the zoom
+    const increaseZoom = event.deltaY < 0
+
+    // Set the new zoom value
+    if (increaseZoom) {
+      scale = (scale + scaleFactor < maxZoom ? scale + scaleFactor : maxZoom)
+    } else {
+      scale = (scale - scaleFactor > minZoom ? scale - scaleFactor : minZoom)
+    }
+
+    /*
+    if (scale <= 1) {
+      scale = 1;
+    }
+
+    if (scale >= 10) {
+      scale = 10;
+    }
+    */
+
+    if (scale !== prevZoom) {
+      if (scale !== minZoom) {
+        [ offsetX, offsetY ] = this.getNewPosition(event.pageX, event.pageY, scale)
+      } else {
+        // Reset to original position
+        [ offsetX, offsetY ] = [0, 0]
+        // [ offsetX, offsetY ] = [this.constructor.defaultState.posX, this.constructor.defaultState.posY]
+      }
+    }
+
+    // offsetX = Math.min(offsetX, 0);
+    // offsetY = Math.min(offsetY, 0);
+
+    console.log('here', scale, offsetX, offsetY);
+
+
+    /*
+    if (isNaN(offsetX)) {
+      offsetX = 0;
+    }
+
+    if (isNaN(offsetY)) {
+      offsetY = 0;
+    }
+    */
+
+    // const newScale = between(minZoom, maxZoom, scale);
+
+    this.props.onZoom({
+      scale,
+      offsetY,
+      offsetX
+    })
+
+    // this.setState({ zoom, posX, posY, transitionDuration: 0.05 })
+  }
+
+  getNewPosition(x, y, zoom) {
+    const [prevZoom, prevPosX, prevPosY] = [this.props.scale, this.props.offsetX, this.props.offsetY]
+
+    if (zoom === 1) {
+      return [0, 0]
+    }
+
+    if (zoom > prevZoom) {
+      // Get container coordinates
+      const rect = this.childRef.current.getBoundingClientRect()
+
+      // Retrieve rectangle dimensions and mouse position
+      const [centerX, centerY] = [rect.width / 2, rect.height / 2]
+      const [relativeX, relativeY] = [x - rect.left, y - rect.top]
+
+      // If we are zooming down, we must try to center to mouse position
+      const [absX, absY] = [(centerX - relativeX) / prevZoom, (centerY - relativeY) / prevZoom]
+      const ratio = zoom - prevZoom
+      return [
+        prevPosX + (absX * ratio),
+        prevPosY + (absY * ratio)
+      ]
+    } else {
+      // If we are zooming down, we shall re-center the element
+      return [
+        (prevPosX * (zoom - 1)) / (prevZoom - 1),
+        (prevPosY * (zoom - 1)) / (prevZoom - 1)
+      ]
+    }
+  }
+
+  render() {
+    return React.Children.map(this.props.children, (child: any) =>
+      React.cloneElement(child, {
+        ...child.props,
+        ref: this.childRef,
+        onWheel: e => {
+          this.onWheel(e);
+          if (child.props.onWheel) {
+            child.props.onWheel(e);
+          }
         }
-
-        componentDidMount() {
-            const component = ReactDOM.findDOMNode(this);
-            if (component) {
-                component.addEventListener('wheel', this.handleWheel);
-            }
-        }
-
-        componentWillUnmount() {
-            if (this.panning) {
-                document.removeEventListener('mousemove', this.handleMouseMove);
-                document.removeEventListener('mouseup', this.handleMouseUp);
-                document.removeEventListener('touchmove', this.handleMouseMove);
-                document.removeEventListener('touchend', this.handleMouseUp);
-            }
-            const component = ReactDOM.findDOMNode(this);
-            if (component) {
-                component.removeEventListener('wheel', this.handleWheel);
-            }
-        }
-
-        handleWheel = (event: WheelEvent) => {
-            const { onPanAndZoom, renderOnChange, disableScrollZoom, onZoom } = this.props;
-
-            if (disableScrollZoom) {
-                return;
-            }
-
-            const x: number | undefined = this.props.x;
-            const y: number | undefined = this.props.y;
-            const scale: number | undefined = this.props.scale;
-            const scaleFactor: number | undefined = this.props.scaleFactor;
-            const minScale: number | undefined = this.props.minScale;
-            const maxScale: number | undefined = this.props.maxScale;
-
-            if (x !== undefined && y !== undefined && scale !== undefined && scaleFactor !== undefined && minScale !== undefined && maxScale !== undefined) {
-                const { deltaY } = event;
-                const newScale = deltaY < 0 ? Math.min((scale + this.ds) * scaleFactor, maxScale) : Math.max((scale + this.ds) / scaleFactor, minScale);
-                const factor = newScale / (scale + this.ds);
-
-                if (factor !== 1) {
-                    const target = ReactDOM.findDOMNode(this);
-                    if (target !== null && 'getBoundingClientRect' in target) {
-                        const { width, height } = target.getBoundingClientRect();
-                        const { clientX, clientY } = this.normalizeTouchPosition(event, target);
-                        const dx = (clientX / width - 0.5) / (scale + this.ds);
-                        const dy = (clientY / height - 0.5) / (scale + this.ds);
-                        const sdx = dx * (1 - 1 / factor);
-                        const sdy = dy * (1 - 1 / factor);
-
-                        this.dx += sdx;
-                        this.dy += sdy;
-                        this.ds = newScale - scale;
-
-                        if (onPanAndZoom) {
-                            onPanAndZoom(x + this.dx, y + this.dy, scale + this.ds, event);
-                        }
-
-                        if (renderOnChange) {
-                            this.forceUpdate();
-                        }
-                    }
-                }
-            }
-
-            if (onZoom) {
-                onZoom(x, y, scale, event);
-            }
-
-            event.preventDefault();
-        };
-
-        panning = false;
-        panLastX = 0;
-        panLastY = 0;
-
-        handleMouseDown = (event: MouseEvent) => {
-            if (!this.panning) {
-                const { onPanStart } = this.props;
-                const target = ReactDOM.findDOMNode(this);
-                if (target !== null && 'getBoundingClientRect' in target) {
-                    const { clientX, clientY } = this.normalizeTouchPosition(event, target);
-                    this.panLastX = clientX;
-                    this.panLastY = clientY;
-                    this.panning = true;
-
-                    document.addEventListener('mousemove', this.handleMouseMove);
-                    document.addEventListener('mouseup', this.handleMouseUp);
-                    document.addEventListener('touchmove', this.handleMouseMove);
-                    document.addEventListener('touchend', this.handleMouseUp);
-
-                    if (onPanStart) {
-                        onPanStart(event);
-                    }
-                }
-            }
-        };
-
-        handleMouseMove = (event: MouseEvent | TouchEvent) => {
-            if (this.panning) {
-                const { onPanMove, renderOnChange, ignorePanOutside } = this.props;
-                const x: number | undefined = this.props.x;
-                const y: number | undefined = this.props.y;
-                const scale: number | undefined = this.props.scale;
-
-                if (x !== undefined && y !== undefined && scale !== undefined) {
-                    const target = ReactDOM.findDOMNode(this);
-                    if (target !== null && 'getBoundingClientRect' in target) {
-                        const { clientX, clientY } = this.normalizeTouchPosition(event, target);
-                        const { width, height } = target.getBoundingClientRect();
-
-                        if (!ignorePanOutside || 0 <= clientX && clientX <= width && 0 <= clientY && clientY <= height) {
-                            const dx = clientX - this.panLastX;
-                            const dy = clientY - this.panLastY;
-                            this.panLastX = clientX;
-                            this.panLastY = clientY;
-                            const sdx = dx / (width * (scale + this.ds));
-                            const sdy = dy / (height * (scale + this.ds));
-                            this.dx -= sdx;
-                            this.dy -= sdy;
-
-                            if (onPanMove) {
-                                onPanMove(x + this.dx, y + this.dy, event);
-                            }
-
-                            if (renderOnChange) {
-                                this.forceUpdate();
-                            }
-                        }
-                    }
-                }
-            }
-        };
-
-        handleMouseUp = (event: MouseEvent | TouchEvent) => {
-            if (this.panning) {
-                const { onPanEnd, renderOnChange, ignorePanOutside } = this.props;
-                const x: number | undefined = this.props.x;
-                const y: number | undefined = this.props.y;
-                const scale: number | undefined = this.props.scale;
-
-                document.removeEventListener('mousemove', this.handleMouseMove);
-                document.removeEventListener('mouseup', this.handleMouseUp);
-                document.removeEventListener('touchmove', this.handleMouseMove);
-                document.removeEventListener('touchend', this.handleMouseUp);
-
-                if (x !== undefined && y !== undefined && scale !== undefined) {
-                    const target = ReactDOM.findDOMNode(this);
-                    if (target !== null && 'getBoundingClientRect' in target) {
-                        try {
-                            const { clientX, clientY } = this.normalizeTouchPosition(event, target);
-                            const { width, height } = target.getBoundingClientRect();
-
-                            if (!ignorePanOutside || 0 <= clientX && clientX <= width && 0 <= clientY && clientY <= height) {
-                                const dx = clientX - this.panLastX;
-                                const dy = clientY - this.panLastY;
-                                this.panLastX = clientX;
-                                this.panLastY = clientY;
-                                const sdx = dx / (width * (scale + this.ds));
-                                const sdy = dy / (height * (scale + this.ds));
-                                this.dx -= sdx;
-                                this.dy -= sdy;
-                            }
-                        } catch (error) {
-                            // Happens when touches are used
-                        }
-                    }
-
-                    this.panning = false;
-
-                    if (onPanEnd) {
-                        onPanEnd(x + this.dx, y + this.dy, event);
-                    }
-
-                    if (renderOnChange) {
-                        this.forceUpdate();
-                    }
-                }
-            }
-        };
-
-        normalizeTouchPosition(event: MouseEvent | TouchEvent, parent: Element) {
-            const position = {
-                clientX: ('targetTouches' in event) ? event.targetTouches[0].pageX : event.clientX,
-                clientY: ('targetTouches' in event) ? event.targetTouches[0].pageY : event.clientY
-            };
-
-            while ((parent as HTMLElement).offsetParent) {
-                position.clientX -= (parent as HTMLElement).offsetLeft - parent.scrollLeft;
-                position.clientY -= (parent as HTMLElement).offsetTop - parent.scrollTop;
-                parent = (parent as HTMLElement).offsetParent;
-            }
-
-            return position;
-        }
-
-        render() {
-            const { children, scaleFactor, x: tempX, y: tempY, scale: tempScale, minScale, maxScale, onPanStart, onPanMove, onPanEnd, onZoom, onPanAndZoom, renderOnChange, passOnProps, ignorePanOutside, disableScrollZoom, ...other } = this.props;
-            const x: number | undefined = this.props.x;
-            const y: number | undefined = this.props.y;
-            const scale: number | undefined = this.props.scale;
-
-            if (x !== undefined && y !== undefined && scale !== undefined) {
-                const passedProps = passOnProps ? { x: x + this.dx, y: y + this.dy, scale: scale + this.ds } : {};
-
-                return (
-                    <WrappedComponent
-                        {...passedProps}
-                        {...other}
-                        onMouseDown={this.handleMouseDown}
-                        onTouchStart={this.handleMouseDown}
-                    >
-                        {children}
-                    </WrappedComponent>
-                );
-            } else {
-                return null;
-            }
-        }
-    } as any as React.ComponentClass<Overwrite<P, PanAndZoomHOCProps>>;
-};
+      })
+    );
+  }
+}

--- a/src/common/Gestures/Zoom.tsx
+++ b/src/common/Gestures/Zoom.tsx
@@ -90,7 +90,7 @@ export class Zoom extends Component<ZoomGestureProps> {
     return outside;
   }
 
-  onWheel(event: MouseWheelEvent) {
+  onWheel(event) {
     const { disableMouseWheel, matrix, onZoomEnd } = this.props;
 
     if (!disableMouseWheel) {

--- a/src/common/Gestures/Zoom.tsx
+++ b/src/common/Gestures/Zoom.tsx
@@ -1,183 +1,291 @@
-import React, { Component, createRef } from 'react';
-import { toggleTextSelection } from '../utils/selection';
-import { getPointFromTouch, getPositionForTarget } from '../utils/position';
-import { getDistanceBetweenPoints, between, getMidpoint } from './pinchUtils';
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 
-interface ZoomGestureProps {
-  disabled?: boolean;
-  maxZoom: number;
-  minZoom: number;
-  zoomStep: number;
-  scale: number;
-  offsetX: number;
-  offsetY: number;
-  disableMouseWheel?: boolean;
-  onZoom: (event: ZoomEvent) => void;
-  onZoomEnd: () => void;
+export type Overwrite<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U;
+
+export interface PanAndZoomHOCProps {
+    x?: number;
+    y?: number;
+    scale?: number;
+    scaleFactor?: number;
+    minScale?: number;
+    maxScale?: number;
+    renderOnChange?: boolean;
+    passOnProps?: boolean;
+    ignorePanOutside?: boolean;
+    disableScrollZoom?: boolean;
+    onPanStart?: (event: MouseEvent | TouchEvent) => void;
+    onPanMove?: (x: number, y: number, event: MouseEvent | TouchEvent) => void;
+    onPanEnd?: (x: number, y: number, event: MouseEvent | TouchEvent) => void;
+    onZoom?: (x: number | undefined, y: number | undefined, scale: number | undefined, event: WheelEvent) => void;
+    onPanAndZoom?: (x: number, y: number, scale: number, event: WheelEvent) => void;
 }
 
-export interface ZoomEvent {
-  scale: number;
-  offsetX: number;
-  offsetY: number;
-}
+export function panAndZoom<P>(WrappedComponent: React.SFC<P> | React.ComponentClass<P> | string): React.ComponentClass<Overwrite<P, PanAndZoomHOCProps>> {
+    return class PanAndZoomHOC extends React.PureComponent<PanAndZoomHOCProps, never> {
+        /*
+        static propTypes = {
+            x: PropTypes.number,
+            y: PropTypes.number,
+            scale: PropTypes.number,
+            scaleFactor: PropTypes.number,
+            minScale: PropTypes.number,
+            maxScale: PropTypes.number,
+            renderOnChange: PropTypes.bool,
+            passOnProps: PropTypes.bool,
+            ignorePanOutside: PropTypes.bool,
+            disableScrollZoom: PropTypes.bool,
+            onPanStart: PropTypes.func,
+            onPanMove: PropTypes.func,
+            onPanEnd: PropTypes.func,
+            onZoom: PropTypes.func,
+            onPanAndZoom: PropTypes.func
+        };
+        */
 
-export class Zoom extends Component<ZoomGestureProps> {
-  lastDistance: any;
-  firstMidpoint: any;
-  timeout: any;
-  childRef = createRef<SVGGElement>();
+        static defaultProps = {
+            x: 0.5,
+            y: 0.5,
+            scale: 1,
+            scaleFactor: Math.sqrt(2),
+            minScale: Number.EPSILON,
+            maxScale: Number.POSITIVE_INFINITY,
+            renderOnChange: false,
+            passOnProps: false
+        };
 
-  componentDidMount() {
-    if (!this.props.disabled) {
-      // Manually bind due to pinch issues not being prevented
-      // https://github.com/facebook/react/issues/9809
-      if (this.childRef.current) {
-        this.childRef.current.addEventListener('touchstart', this.onTouchStart);
-      }
-    }
-  }
+        dx: number = 0;
+        dy: number = 0;
+        ds: number = 0;
+        element: Element | null = null;
 
-  componentWillUnmount() {
-    window.removeEventListener('touchstart', this.onTouchStart);
-    window.removeEventListener('touchmove', this.onTouchMove);
-    window.removeEventListener('touchend', this.onTouchEnd);
-    toggleTextSelection(true);
-  }
-
-  onTouchStart = (event: TouchEvent) => {
-    if (event.touches.length === 2 && this.childRef.current) {
-      event.preventDefault();
-      event.stopPropagation();
-      toggleTextSelection(false);
-
-      const pointA = getPointFromTouch(event.touches[0], this.childRef.current);
-      const pointB = getPointFromTouch(event.touches[1], this.childRef.current);
-      this.lastDistance = getDistanceBetweenPoints(pointA, pointB);
-      this.firstMidpoint = getMidpoint(pointA, pointB);
-
-      window.addEventListener('touchmove', this.onTouchMove);
-      window.addEventListener('touchend', this.onTouchEnd);
-    }
-  };
-
-  onTouchMove = (event: TouchEvent) => {
-    if (event.touches.length === 2 && this.childRef.current) {
-      event.preventDefault();
-      event.stopPropagation();
-
-      const pointA = getPointFromTouch(event.touches[0], this.childRef.current);
-      const pointB = getPointFromTouch(event.touches[1], this.childRef.current);
-      const distance = getDistanceBetweenPoints(pointA, pointB);
-
-      const { maxZoom, zoomStep, offsetX, offsetY, scale, minZoom } = this.props;
-      const delta = distance - this.lastDistance;
-      const ratio = Math.exp((delta / 30) * zoomStep);
-      const newScale = between(1, maxZoom, scale * ratio);
-
-      if (newScale <= minZoom) {
-        return;
-      }
-
-      const newOffsetX = Math.min(
-        (offsetX - this.firstMidpoint.x) * ratio + this.firstMidpoint.x,
-        0
-      );
-
-      const newOffsetY = Math.min(
-        (offsetY - this.firstMidpoint.y) * ratio + this.firstMidpoint.y,
-        0
-      );
-
-      if (scale < this.props.maxZoom) {
-        this.props.onZoom({
-          scale: newScale,
-          offsetX: newOffsetX,
-          offsetY: newOffsetY
-        });
-      }
-
-      this.lastDistance = distance;
-    }
-  };
-
-  onTouchEnd = (event: TouchEvent) => {
-    event.preventDefault();
-    event.stopPropagation();
-
-    window.removeEventListener('touchmove', this.onTouchMove);
-    window.removeEventListener('touchend', this.onTouchEnd);
-
-    toggleTextSelection(true);
-    this.props.onZoomEnd();
-  };
-
-  onWheel(event: React.MouseEvent) {
-    const {
-      disabled,
-      maxZoom,
-      zoomStep,
-      scale,
-      offsetX,
-      offsetY,
-      onZoomEnd,
-      disableMouseWheel,
-      minZoom
-    } = this.props;
-
-    if (!disabled && !disableMouseWheel) {
-      const nativeEvent = event.nativeEvent as WheelEvent;
-      const positions = getPositionForTarget(nativeEvent);
-      const wheel = (nativeEvent.deltaY / 120) * -1;
-      const ratio = Math.exp(wheel * zoomStep);
-      const roundedScale = Math.ceil(scale * ratio);
-      const inBounds = roundedScale <= maxZoom && roundedScale >= 1;
-
-      if (inBounds && roundedScale !== scale) {
-        event.preventDefault();
-
-        const newScale = between(1, maxZoom, scale * ratio);
-
-        if (newScale <= minZoom) {
-          return;
+        componentWillReceiveProps(nextProps: PanAndZoomHOCProps) {
+            if (this.props.x !== nextProps.x || this.props.y !== nextProps.y) {
+                this.dx = 0;
+                this.dy = 0;
+            }
+            if (this.props.scale !== nextProps.scale) {
+                this.ds = 0;
+            }
         }
 
-        const newOffsetX = Math.min(
-          (offsetX - positions.x) * ratio + positions.x,
-          0
-        );
-
-        const newOffsetY = Math.min(
-          (offsetY - positions.y) * ratio + positions.y,
-          0
-        );
-
-        this.props.onZoom({
-          scale: newScale,
-          offsetX: newOffsetX,
-          offsetY: newOffsetY
-        });
-
-        clearTimeout(this.timeout);
-        this.timeout = setTimeout(() => {
-          onZoomEnd();
-        }, 500);
-      }
-    }
-  }
-
-  render() {
-    return React.Children.map(this.props.children, (child: any) =>
-      React.cloneElement(child, {
-        ...child.props,
-        ref: this.childRef,
-        onWheel: e => {
-          this.onWheel(e);
-          if (child.props.onWheel) {
-            child.props.onWheel(e);
-          }
+        componentDidMount() {
+            const component = ReactDOM.findDOMNode(this);
+            if (component) {
+                component.addEventListener('wheel', this.handleWheel);
+            }
         }
-      })
-    );
-  }
-}
+
+        componentWillUnmount() {
+            if (this.panning) {
+                document.removeEventListener('mousemove', this.handleMouseMove);
+                document.removeEventListener('mouseup', this.handleMouseUp);
+                document.removeEventListener('touchmove', this.handleMouseMove);
+                document.removeEventListener('touchend', this.handleMouseUp);
+            }
+            const component = ReactDOM.findDOMNode(this);
+            if (component) {
+                component.removeEventListener('wheel', this.handleWheel);
+            }
+        }
+
+        handleWheel = (event: WheelEvent) => {
+            const { onPanAndZoom, renderOnChange, disableScrollZoom, onZoom } = this.props;
+
+            if (disableScrollZoom) {
+                return;
+            }
+
+            const x: number | undefined = this.props.x;
+            const y: number | undefined = this.props.y;
+            const scale: number | undefined = this.props.scale;
+            const scaleFactor: number | undefined = this.props.scaleFactor;
+            const minScale: number | undefined = this.props.minScale;
+            const maxScale: number | undefined = this.props.maxScale;
+
+            if (x !== undefined && y !== undefined && scale !== undefined && scaleFactor !== undefined && minScale !== undefined && maxScale !== undefined) {
+                const { deltaY } = event;
+                const newScale = deltaY < 0 ? Math.min((scale + this.ds) * scaleFactor, maxScale) : Math.max((scale + this.ds) / scaleFactor, minScale);
+                const factor = newScale / (scale + this.ds);
+
+                if (factor !== 1) {
+                    const target = ReactDOM.findDOMNode(this);
+                    if (target !== null && 'getBoundingClientRect' in target) {
+                        const { width, height } = target.getBoundingClientRect();
+                        const { clientX, clientY } = this.normalizeTouchPosition(event, target);
+                        const dx = (clientX / width - 0.5) / (scale + this.ds);
+                        const dy = (clientY / height - 0.5) / (scale + this.ds);
+                        const sdx = dx * (1 - 1 / factor);
+                        const sdy = dy * (1 - 1 / factor);
+
+                        this.dx += sdx;
+                        this.dy += sdy;
+                        this.ds = newScale - scale;
+
+                        if (onPanAndZoom) {
+                            onPanAndZoom(x + this.dx, y + this.dy, scale + this.ds, event);
+                        }
+
+                        if (renderOnChange) {
+                            this.forceUpdate();
+                        }
+                    }
+                }
+            }
+
+            if (onZoom) {
+                onZoom(x, y, scale, event);
+            }
+
+            event.preventDefault();
+        };
+
+        panning = false;
+        panLastX = 0;
+        panLastY = 0;
+
+        handleMouseDown = (event: MouseEvent) => {
+            if (!this.panning) {
+                const { onPanStart } = this.props;
+                const target = ReactDOM.findDOMNode(this);
+                if (target !== null && 'getBoundingClientRect' in target) {
+                    const { clientX, clientY } = this.normalizeTouchPosition(event, target);
+                    this.panLastX = clientX;
+                    this.panLastY = clientY;
+                    this.panning = true;
+
+                    document.addEventListener('mousemove', this.handleMouseMove);
+                    document.addEventListener('mouseup', this.handleMouseUp);
+                    document.addEventListener('touchmove', this.handleMouseMove);
+                    document.addEventListener('touchend', this.handleMouseUp);
+
+                    if (onPanStart) {
+                        onPanStart(event);
+                    }
+                }
+            }
+        };
+
+        handleMouseMove = (event: MouseEvent | TouchEvent) => {
+            if (this.panning) {
+                const { onPanMove, renderOnChange, ignorePanOutside } = this.props;
+                const x: number | undefined = this.props.x;
+                const y: number | undefined = this.props.y;
+                const scale: number | undefined = this.props.scale;
+
+                if (x !== undefined && y !== undefined && scale !== undefined) {
+                    const target = ReactDOM.findDOMNode(this);
+                    if (target !== null && 'getBoundingClientRect' in target) {
+                        const { clientX, clientY } = this.normalizeTouchPosition(event, target);
+                        const { width, height } = target.getBoundingClientRect();
+
+                        if (!ignorePanOutside || 0 <= clientX && clientX <= width && 0 <= clientY && clientY <= height) {
+                            const dx = clientX - this.panLastX;
+                            const dy = clientY - this.panLastY;
+                            this.panLastX = clientX;
+                            this.panLastY = clientY;
+                            const sdx = dx / (width * (scale + this.ds));
+                            const sdy = dy / (height * (scale + this.ds));
+                            this.dx -= sdx;
+                            this.dy -= sdy;
+
+                            if (onPanMove) {
+                                onPanMove(x + this.dx, y + this.dy, event);
+                            }
+
+                            if (renderOnChange) {
+                                this.forceUpdate();
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        handleMouseUp = (event: MouseEvent | TouchEvent) => {
+            if (this.panning) {
+                const { onPanEnd, renderOnChange, ignorePanOutside } = this.props;
+                const x: number | undefined = this.props.x;
+                const y: number | undefined = this.props.y;
+                const scale: number | undefined = this.props.scale;
+
+                document.removeEventListener('mousemove', this.handleMouseMove);
+                document.removeEventListener('mouseup', this.handleMouseUp);
+                document.removeEventListener('touchmove', this.handleMouseMove);
+                document.removeEventListener('touchend', this.handleMouseUp);
+
+                if (x !== undefined && y !== undefined && scale !== undefined) {
+                    const target = ReactDOM.findDOMNode(this);
+                    if (target !== null && 'getBoundingClientRect' in target) {
+                        try {
+                            const { clientX, clientY } = this.normalizeTouchPosition(event, target);
+                            const { width, height } = target.getBoundingClientRect();
+
+                            if (!ignorePanOutside || 0 <= clientX && clientX <= width && 0 <= clientY && clientY <= height) {
+                                const dx = clientX - this.panLastX;
+                                const dy = clientY - this.panLastY;
+                                this.panLastX = clientX;
+                                this.panLastY = clientY;
+                                const sdx = dx / (width * (scale + this.ds));
+                                const sdy = dy / (height * (scale + this.ds));
+                                this.dx -= sdx;
+                                this.dy -= sdy;
+                            }
+                        } catch (error) {
+                            // Happens when touches are used
+                        }
+                    }
+
+                    this.panning = false;
+
+                    if (onPanEnd) {
+                        onPanEnd(x + this.dx, y + this.dy, event);
+                    }
+
+                    if (renderOnChange) {
+                        this.forceUpdate();
+                    }
+                }
+            }
+        };
+
+        normalizeTouchPosition(event: MouseEvent | TouchEvent, parent: Element) {
+            const position = {
+                clientX: ('targetTouches' in event) ? event.targetTouches[0].pageX : event.clientX,
+                clientY: ('targetTouches' in event) ? event.targetTouches[0].pageY : event.clientY
+            };
+
+            while ((parent as HTMLElement).offsetParent) {
+                position.clientX -= (parent as HTMLElement).offsetLeft - parent.scrollLeft;
+                position.clientY -= (parent as HTMLElement).offsetTop - parent.scrollTop;
+                parent = (parent as HTMLElement).offsetParent;
+            }
+
+            return position;
+        }
+
+        render() {
+            const { children, scaleFactor, x: tempX, y: tempY, scale: tempScale, minScale, maxScale, onPanStart, onPanMove, onPanEnd, onZoom, onPanAndZoom, renderOnChange, passOnProps, ignorePanOutside, disableScrollZoom, ...other } = this.props;
+            const x: number | undefined = this.props.x;
+            const y: number | undefined = this.props.y;
+            const scale: number | undefined = this.props.scale;
+
+            if (x !== undefined && y !== undefined && scale !== undefined) {
+                const passedProps = passOnProps ? { x: x + this.dx, y: y + this.dy, scale: scale + this.ds } : {};
+
+                return (
+                    <WrappedComponent
+                        {...passedProps}
+                        {...other}
+                        onMouseDown={this.handleMouseDown}
+                        onTouchStart={this.handleMouseDown}
+                    >
+                        {children}
+                    </WrappedComponent>
+                );
+            } else {
+                return null;
+            }
+        }
+    } as any as React.ComponentClass<Overwrite<P, PanAndZoomHOCProps>>;
+};

--- a/src/common/Gestures/Zoom.tsx
+++ b/src/common/Gestures/Zoom.tsx
@@ -2,7 +2,7 @@ import React, { Component, createRef } from 'react';
 import { toggleTextSelection } from '../utils/selection';
 import { getPointFromTouch, getPointFromMatrix } from '../utils/position';
 import { getDistanceBetweenPoints, getMidpoint } from './pinchUtils';
-import { identity, scale, smoothMatrix, transform, translate, fromObject } from 'transformation-matrix';
+import { scale, smoothMatrix, transform, translate, fromObject } from 'transformation-matrix';
 
 interface ZoomGestureProps {
   disabled?: boolean;
@@ -137,7 +137,7 @@ export class Zoom extends Component<ZoomGestureProps> {
     zoomLevel = Math.max(this.matrix.a, minZoom);
     zoomLevel = zoomLevel * step;
 
-    if (zoomLevel > minZoom && zoomLevel < maxZoom) {
+    if (zoomLevel >= minZoom && zoomLevel <= maxZoom) {
       this.updating = true;
 
       requestAnimationFrame(() => {

--- a/src/common/Gestures/pinchUtils.tsx
+++ b/src/common/Gestures/pinchUtils.tsx
@@ -11,10 +11,27 @@ export const getMidpoint = (pointA, pointB) => ({
  */
 export const getDistanceBetweenPoints = (pointA, pointB) =>
   Math.sqrt(
-    Math.pow(pointA.y - pointB.y, 2) + Math.pow(pointA.x - pointB.x, 2)
+    Math.pow(pointB.y - pointA.y, 2) + Math.pow(pointB.x - pointA.x, 2)
   );
 
 /**
- * Gets the value between a set of numeric values.
+ * Get touch points.
  */
-export const between = (min, max, value) => Math.min(max, Math.max(min, value));
+export function getTouchPoints(event, node) {
+  const { left, top } = node.getBoundingClientRect();
+
+  const [pointA, pointB] = [...event.touches].map(touch => ({
+    x: touch.clientX - Math.round(left),
+    y: touch.clientY - Math.round(top)
+  }));
+
+  const distance = getDistanceBetweenPoints(pointA, pointB);
+  const midpoint = getMidpoint(pointA, pointB);
+
+  return {
+    pointA,
+    pointB,
+    distance,
+    midpoint
+  };
+}

--- a/src/common/TooltipArea/Tooltip.tsx
+++ b/src/common/TooltipArea/Tooltip.tsx
@@ -117,8 +117,8 @@ export class Tooltip extends React.Component<TooltipProps, TooltipState> {
         {...rest}
         visible={this.state.visible}
         content={this.renderContent}
-        closeOnBodyClick={true}
-        closeOnEscape={true}
+        closeOnBodyClick={false}
+        closeOnEscape={false}
         onActivate={bind(this.onActivate, this)}
         onDeactivate={bind(this.onDeactivate, this)}
       >

--- a/src/common/ZoomPan/ChartZoomPan.tsx
+++ b/src/common/ZoomPan/ChartZoomPan.tsx
@@ -14,7 +14,6 @@ export interface ChartZoomPanProps {
   domain?: [ChartDataTypes, ChartDataTypes];
   axisType: 'value' | 'time' | 'category' | 'duration';
   roundDomains: boolean;
-  onZoomPan?: (event: ZoomPanChangeEvent) => void;
   height: number;
   width: number;
   scale: number;
@@ -26,6 +25,7 @@ export interface ChartZoomPanProps {
   zoomStep: number;
   decay: boolean;
   disableMouseWheel?: boolean;
+  onZoomPan?: (event: ZoomPanChangeEvent) => void;
 }
 
 export class ChartZoomPan extends Component<ChartZoomPanProps> {
@@ -48,8 +48,8 @@ export class ChartZoomPan extends Component<ChartZoomPanProps> {
       const newScale = scale.copy().domain(
         scale
           .range()
-          .map(x => (x - event.offsetX) / event.scale)
-          .map(scale.invert, event.offsetX)
+          .map(x => (x - event.x) / event.scale)
+          .map(scale.invert, event.x)
       );
 
       onZoomPan!({
@@ -62,7 +62,7 @@ export class ChartZoomPan extends Component<ChartZoomPanProps> {
   getOffset() {
     let zoomOffset = {
       scale: undefined,
-      offsetX: undefined
+      x: undefined
     } as any;
 
     const {
@@ -91,7 +91,7 @@ export class ChartZoomPan extends Component<ChartZoomPanProps> {
 
       zoomOffset = {
         scale: scale,
-        offsetX: -offset
+        x: -offset
       };
     }
 
@@ -100,13 +100,13 @@ export class ChartZoomPan extends Component<ChartZoomPanProps> {
 
   render() {
     const { data, height, children, width, onZoomPan, ...rest } = this.props;
-    const { scale, offsetX } = this.getOffset();
+    const { scale, x } = this.getOffset();
 
     return (
       <ZoomPan
         {...rest}
         scale={scale}
-        offsetX={offsetX}
+        x={x}
         height={height}
         width={width}
         pannable={scale > 1}

--- a/src/common/ZoomPan/ChartZoomPan.tsx
+++ b/src/common/ZoomPan/ChartZoomPan.tsx
@@ -37,15 +37,13 @@ export class ChartZoomPan extends Component<ChartZoomPanProps> {
     const { width, data, axisType, roundDomains, onZoomPan } = this.props;
     const can = event.type === 'zoom' || (event.type === 'pan' && event.scale > 1);
 
-   //  if (can) {
+    if (can) {
       const scale: any = getXScale({
         width: width,
         type: axisType,
         roundDomains,
         data
       });
-
-      console.log('here', event.offsetX, event.scale);
 
       const newScale = scale.copy().domain(
         scale
@@ -54,13 +52,11 @@ export class ChartZoomPan extends Component<ChartZoomPanProps> {
           .map(scale.invert, event.offsetX)
       );
 
-      console.log('here', )
-
       onZoomPan!({
         domain: newScale.domain(),
         isZoomed: event.scale !== 1
       });
-    // }
+    }
   }
 
   getOffset() {
@@ -94,7 +90,7 @@ export class ChartZoomPan extends Component<ChartZoomPanProps> {
       offset = offset * scale;
 
       zoomOffset = {
-        scale,
+        scale: scale,
         offsetX: -offset
       };
     }

--- a/src/common/ZoomPan/ChartZoomPan.tsx
+++ b/src/common/ZoomPan/ChartZoomPan.tsx
@@ -37,13 +37,15 @@ export class ChartZoomPan extends Component<ChartZoomPanProps> {
     const { width, data, axisType, roundDomains, onZoomPan } = this.props;
     const can = event.type === 'zoom' || (event.type === 'pan' && event.scale > 1);
 
-    if (can) {
+   //  if (can) {
       const scale: any = getXScale({
         width: width,
         type: axisType,
         roundDomains,
         data
       });
+
+      console.log('here', event.offsetX, event.scale);
 
       const newScale = scale.copy().domain(
         scale
@@ -52,11 +54,13 @@ export class ChartZoomPan extends Component<ChartZoomPanProps> {
           .map(scale.invert, event.offsetX)
       );
 
+      console.log('here', )
+
       onZoomPan!({
         domain: newScale.domain(),
         isZoomed: event.scale !== 1
       });
-    }
+    // }
   }
 
   getOffset() {
@@ -90,7 +94,7 @@ export class ChartZoomPan extends Component<ChartZoomPanProps> {
       offset = offset * scale;
 
       zoomOffset = {
-        scale: scale,
+        scale,
         offsetX: -offset
       };
     }

--- a/src/common/ZoomPan/ChartZoomPan.tsx
+++ b/src/common/ZoomPan/ChartZoomPan.tsx
@@ -49,7 +49,7 @@ export class ChartZoomPan extends Component<ChartZoomPanProps> {
         scale
           .range()
           .map(x => (x - event.x) / event.scale)
-          .map(scale.invert, event.x)
+          .map(scale.clamp(true).invert, event.x)
       );
 
       onZoomPan!({

--- a/src/common/ZoomPan/ZoomPan.story.tsx
+++ b/src/common/ZoomPan/ZoomPan.story.tsx
@@ -101,7 +101,7 @@ class GenericZoomPanStory extends Component<{}, any> {
             minZoom={1}
             decay={false}
             maxZoom={10}
-            constrained={false}
+            constrain={false}
             scale={scale}
             offsetY={offsetX}
             offsetX={offsetY}

--- a/src/common/ZoomPan/ZoomPan.story.tsx
+++ b/src/common/ZoomPan/ZoomPan.story.tsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { storiesOf } from '@storybook/react';
 import { largeDateData, largeSignalChartData } from '../demo';
 import { LineChart, LineSeries } from '../../LineChart';
-import { ChartZoomPan } from '../ZoomPan';
+import { ChartZoomPan, ZoomPan } from '../ZoomPan';
 import { ScatterPlot, ScatterSeries, ScatterPoint } from '../../ScatterPlot';
 import { AreaChart, AreaSeries } from '../../AreaChart';
 import { TooltipArea } from '../TooltipArea';
@@ -74,7 +74,50 @@ storiesOf('Charts/Zoom Pan', module)
       }
     />
   ))
+  .add('Generic Zoom Pan', () => <GenericZoomPanStory />)
   .add('Default Zoom', () => <DefaultZoomStory />);
+
+class GenericZoomPanStory extends Component<{}, any> {
+  state = {
+    zoomLevel: 1,
+    offsetX: 125,
+    offsetY: 100
+  };
+
+  onZoomPan = (event) => {
+    this.setState(event);
+  };
+
+  render() {
+    const { offsetX, offsetY, zoomLevel } = this.state;
+
+    // console.log('here', offsetX, offsetY)
+
+    return (
+      <div>
+        <svg height="350" width="500">
+          <ZoomPan
+            height={350}
+            width={500}
+            pannable={true}
+            contained={false}
+            decay={false}
+            scale={zoomLevel}
+            offsetY={offsetX}
+            offsetX={offsetY}
+            onZoomPan={this.onZoomPan}
+          >
+            <g transform={`translate(${offsetX}, ${offsetY}) scale(${zoomLevel})`}>
+              <circle cx="50" cy="100" r="10" fill="blue" />
+              <circle cx="100" cy="100" r="10" fill="red" />
+              <circle cx="150" cy="100" r="10" fill="green" />
+            </g>
+          </ZoomPan>
+        </svg>
+      </div>
+    );
+  }
+}
 
 class DefaultZoomStory extends Component<{}, { domain: [any, any] }> {
   state: { domain: [any, any] } = {

--- a/src/common/ZoomPan/ZoomPan.story.tsx
+++ b/src/common/ZoomPan/ZoomPan.story.tsx
@@ -99,9 +99,9 @@ class GenericZoomPanStory extends Component<{}, any> {
             width={500}
             pannable={true}
             minZoom={1}
-            maxZoom={10}
-            contained={false}
             decay={false}
+            maxZoom={10}
+            constrained={false}
             scale={scale}
             offsetY={offsetX}
             offsetX={offsetY}

--- a/src/common/ZoomPan/ZoomPan.story.tsx
+++ b/src/common/ZoomPan/ZoomPan.story.tsx
@@ -80,8 +80,8 @@ storiesOf('Charts/Zoom Pan', module)
 class GenericZoomPanStory extends Component<{}, any> {
   state = {
     scale: 1,
-    offsetX: 0,
-    offsetY: 0
+    x: 0,
+    y: 0
   };
 
   onZoomPan = (event) => {
@@ -89,7 +89,7 @@ class GenericZoomPanStory extends Component<{}, any> {
   };
 
   render() {
-    const { offsetX, offsetY, scale } = this.state;
+    const { x, y, scale } = this.state;
 
     return (
       <div style={{ border: 'dotted 2px red' }}>
@@ -103,11 +103,11 @@ class GenericZoomPanStory extends Component<{}, any> {
             maxZoom={10}
             constrain={false}
             scale={scale}
-            offsetY={offsetX}
-            offsetX={offsetY}
+            x={x}
+            y={y}
             onZoomPan={this.onZoomPan}
           >
-            <g transform={`translate(${offsetX}, ${offsetY}) scale(${scale})`}>
+            <g transform={`translate(${x}, ${y}) scale(${scale})`}>
               <circle cx="50" cy="100" r="10" fill="blue" />
               <circle cx="100" cy="100" r="10" fill="red" />
               <circle cx="150" cy="100" r="10" fill="green" />

--- a/src/common/ZoomPan/ZoomPan.story.tsx
+++ b/src/common/ZoomPan/ZoomPan.story.tsx
@@ -80,8 +80,8 @@ storiesOf('Charts/Zoom Pan', module)
 class GenericZoomPanStory extends Component<{}, any> {
   state = {
     zoomLevel: 1,
-    offsetX: 125,
-    offsetY: 100
+    offsetX: 0,
+    offsetY: 0
   };
 
   onZoomPan = (event) => {
@@ -94,12 +94,14 @@ class GenericZoomPanStory extends Component<{}, any> {
     // console.log('here', offsetX, offsetY)
 
     return (
-      <div>
+      <div style={{ border: 'dotted 2px red' }}>
         <svg height="350" width="500">
           <ZoomPan
             height={350}
             width={500}
             pannable={true}
+            minZoom={1}
+            maxZoom={10}
             contained={false}
             decay={false}
             scale={zoomLevel}

--- a/src/common/ZoomPan/ZoomPan.story.tsx
+++ b/src/common/ZoomPan/ZoomPan.story.tsx
@@ -79,7 +79,7 @@ storiesOf('Charts/Zoom Pan', module)
 
 class GenericZoomPanStory extends Component<{}, any> {
   state = {
-    zoomLevel: 1,
+    scale: 1,
     offsetX: 0,
     offsetY: 0
   };
@@ -89,9 +89,7 @@ class GenericZoomPanStory extends Component<{}, any> {
   };
 
   render() {
-    const { offsetX, offsetY, zoomLevel } = this.state;
-
-    // console.log('here', offsetX, offsetY)
+    const { offsetX, offsetY, scale } = this.state;
 
     return (
       <div style={{ border: 'dotted 2px red' }}>
@@ -104,12 +102,12 @@ class GenericZoomPanStory extends Component<{}, any> {
             maxZoom={10}
             contained={false}
             decay={false}
-            scale={zoomLevel}
+            scale={scale}
             offsetY={offsetX}
             offsetX={offsetY}
             onZoomPan={this.onZoomPan}
           >
-            <g transform={`translate(${offsetX}, ${offsetY}) scale(${zoomLevel})`}>
+            <g transform={`translate(${offsetX}, ${offsetY}) scale(${scale})`}>
               <circle cx="50" cy="100" r="10" fill="blue" />
               <circle cx="100" cy="100" r="10" fill="red" />
               <circle cx="150" cy="100" r="10" fill="green" />

--- a/src/common/ZoomPan/ZoomPan.tsx
+++ b/src/common/ZoomPan/ZoomPan.tsx
@@ -218,6 +218,9 @@ export class ZoomPan extends Component<ZoomPanProps, ZoomPanState> {
             scale={scale}
             offsetX={offsetX}
             offsetY={offsetY}
+            constrain={constrain}
+            height={height}
+            width={width}
             onZoom={bind(this.onZoom, this)}
             onZoomEnd={bind(this.onZoomEnd, this)}
             matrix={matrix}

--- a/src/common/ZoomPan/ZoomPan.tsx
+++ b/src/common/ZoomPan/ZoomPan.tsx
@@ -84,20 +84,18 @@ export class ZoomPan extends Component<ZoomPanProps, ZoomPanState> {
     return width * scale! - width;
   }
 
-  ensureRange(offset: number, delta: number) {
+  ensureRange(offset: number) {
     const { contained } = this.props;
-    const prevOffset = offset;
-    let newOffset = delta + prevOffset;
 
     if (contained) {
-      if (-newOffset <= 0) {
-        newOffset = 0;
-      } else if (-newOffset > this.getEndOffset()) {
-        newOffset = prevOffset;
+      if (-offset <= 0) {
+        offset = 0;
+      } else if (-offset > this.getEndOffset()) {
+        offset = offset;
       }
     }
 
-    return newOffset;
+    return offset;
   }
 
   onPanStart() {
@@ -109,9 +107,9 @@ export class ZoomPan extends Component<ZoomPanProps, ZoomPanState> {
     this.observer = value(this.props.offsetX);
   }
 
-  onPanMove(event: PanMoveEvent) {
-    const offsetX = this.ensureRange(this.props.offsetX, event.deltaX);
-    const offsetY = this.ensureRange(this.props.offsetY, event.deltaY);
+  onPanMove(event: any) {
+    const offsetX = this.ensureRange(event.offsetX);
+    const offsetY = this.ensureRange(event.offsetY);
 
     this.observer && this.observer.update(offsetX);
 
@@ -155,11 +153,14 @@ export class ZoomPan extends Component<ZoomPanProps, ZoomPanState> {
 
   onZoom(event: ZoomEvent) {
     this.stopDecay();
+    const inRange = this.ensureRange(event.offsetX);
 
-    this.props.onZoomPan({
-      ...event,
-      type: 'zoom'
-    });
+    if (inRange) {
+      this.props.onZoomPan({
+        ...event,
+        type: 'zoom'
+      });
+    }
   }
 
   onZoomEnd() {
@@ -177,7 +178,6 @@ export class ZoomPan extends Component<ZoomPanProps, ZoomPanState> {
       pannable,
       maxZoom,
       minZoom,
-      zoomStep,
       zoomable,
       scale,
       offsetX,
@@ -201,7 +201,6 @@ export class ZoomPan extends Component<ZoomPanProps, ZoomPanState> {
             disableMouseWheel={disableMouseWheel}
             maxZoom={maxZoom}
             minZoom={minZoom}
-            zoomStep={zoomStep}
             scale={scale}
             offsetX={offsetX}
             offsetY={offsetY}

--- a/src/common/ZoomPan/ZoomPan.tsx
+++ b/src/common/ZoomPan/ZoomPan.tsx
@@ -55,12 +55,23 @@ export class ZoomPan extends Component<ZoomPanProps, ZoomPanState> {
 
   observer?: ValueReaction;
   decay?: ColdSubscription;
-  matrix = identity();
+  matrix: any;
 
   state: ZoomPanState = {
     isZooming: false,
     isPanning: false
   };
+
+  constructor(props: ZoomPanProps) {
+    super(props);
+
+    this.matrix = fromObject({
+      ...identity(),
+      a: props.scale,
+      e: props.x,
+      f: props.y
+    });
+  }
 
   componentWillUnmount() {
     this.stopDecay();

--- a/src/common/ZoomPan/ZoomPan.tsx
+++ b/src/common/ZoomPan/ZoomPan.tsx
@@ -8,8 +8,8 @@ import { identity, fromObject } from 'transformation-matrix';
 
 export interface ZoomPanEvent {
   scale: number;
-  offsetX: number;
-  offsetY: number;
+  x: number;
+  y: number;
   type: 'zoom' | 'pan';
 }
 
@@ -17,8 +17,8 @@ export interface ZoomPanProps {
   height: number;
   width: number;
   scale: number;
-  offsetX: number;
-  offsetY: number;
+  x: number;
+  y: number;
   pannable: boolean;
   zoomable: boolean;
   disabled?: boolean;
@@ -47,8 +47,8 @@ export class ZoomPan extends Component<ZoomPanProps, ZoomPanState> {
     decay: true,
     height: 0,
     width: 0,
-    offsetX: 0,
-    offsetY: 0,
+    x: 0,
+    y: 0,
     scale: 1,
     onZoomPan: () => undefined
   };
@@ -76,51 +76,30 @@ export class ZoomPan extends Component<ZoomPanProps, ZoomPanState> {
     }
   }
 
-  getEndOffset() {
-    const { width, scale } = this.props;
-    return width * scale - width;
-  }
-
-  ensureRange(offset: number) {
-    const { constrain } = this.props;
-
-    if (constrain) {
-      if (-offset <= 0) {
-        offset = 0;
-      } else if (-offset > this.getEndOffset()) {
-        offset = offset;
-      }
-    }
-
-    return offset;
-  }
-
   onPanStart() {
     this.setState({
       isPanning: true
     });
 
     this.stopDecay();
-    this.observer = value(this.props.offsetX);
+    this.observer = value(this.props.x);
   }
 
-  onPanMove(event) {
-    // const offsetX = this.ensureRange(event.offsetX);
-    // const offsetY = this.ensureRange(event.offsetY);
-
+  onPanMove(event: PanMoveEvent) {
     this.matrix = fromObject(event.matrix);
 
-    this.observer && this.observer.update(event.offsetX);
+    this.observer && this.observer.update(event.x);
 
     this.props.onZoomPan({
       scale: this.props.scale,
-      offsetX: event.offsetX,
-      offsetY: event.offsetY,
+      x: event.x,
+      y: event.y,
       type: 'pan'
     });
   }
 
   onPanEnd() {
+    /*
     if (false) {
     // if (this.observer && this.props.decay) {
       const end = this.getEndOffset();
@@ -150,22 +129,19 @@ export class ZoomPan extends Component<ZoomPanProps, ZoomPanState> {
           complete: () => this.setState({ isPanning: false })
         });
     } else {
+      */
       this.setState({ isPanning: false });
-    }
+    // }
   }
 
-  onZoom(event) {
+  onZoom(event: ZoomEvent) {
     this.stopDecay();
-    const inRange = this.ensureRange(event.offsetX);
+    this.matrix = fromObject(event.matrix);
 
-    // if (inRange) {
-      this.matrix = fromObject(event.matrix);
-
-      this.props.onZoomPan({
-        ...event,
-        type: 'zoom'
-      });
-    // }
+    this.props.onZoomPan({
+      ...event,
+      type: 'zoom'
+    });
   }
 
   onZoomEnd() {
@@ -185,8 +161,8 @@ export class ZoomPan extends Component<ZoomPanProps, ZoomPanState> {
       minZoom,
       zoomable,
       scale,
-      offsetX,
-      offsetY,
+      x,
+      y,
       disableMouseWheel,
       constrain
     } = this.props;
@@ -197,8 +173,8 @@ export class ZoomPan extends Component<ZoomPanProps, ZoomPanState> {
 
     return (
       <Pan
-        offsetX={offsetX}
-        offsetY={offsetY}
+        x={x}
+        y={y}
         scale={scale}
         matrix={matrix}
         constrain={constrain}
@@ -216,8 +192,8 @@ export class ZoomPan extends Component<ZoomPanProps, ZoomPanState> {
             maxZoom={maxZoom}
             minZoom={minZoom}
             scale={scale}
-            offsetX={offsetX}
-            offsetY={offsetY}
+            x={x}
+            y={y}
             constrain={constrain}
             height={height}
             width={width}

--- a/src/common/ZoomPan/ZoomPan.tsx
+++ b/src/common/ZoomPan/ZoomPan.tsx
@@ -25,7 +25,7 @@ export interface ZoomPanProps {
   maxZoom: number;
   minZoom: number;
   zoomStep: number;
-  constrained: boolean;
+  constrain: boolean;
   decay: boolean;
   disableMouseWheel?: boolean;
   onZoomPan: (event: ZoomPanEvent) => void;
@@ -43,7 +43,7 @@ export class ZoomPan extends Component<ZoomPanProps, ZoomPanState> {
     zoomStep: 0.1,
     pannable: true,
     zoomable: true,
-    constrained: true,
+    constrain: true,
     decay: true,
     height: 0,
     width: 0,
@@ -82,9 +82,9 @@ export class ZoomPan extends Component<ZoomPanProps, ZoomPanState> {
   }
 
   ensureRange(offset: number) {
-    const { constrained } = this.props;
+    const { constrain } = this.props;
 
-    if (constrained) {
+    if (constrain) {
       if (-offset <= 0) {
         offset = 0;
       } else if (-offset > this.getEndOffset()) {
@@ -105,17 +105,17 @@ export class ZoomPan extends Component<ZoomPanProps, ZoomPanState> {
   }
 
   onPanMove(event) {
-    const offsetX = this.ensureRange(event.offsetX);
-    const offsetY = this.ensureRange(event.offsetY);
+    // const offsetX = this.ensureRange(event.offsetX);
+    // const offsetY = this.ensureRange(event.offsetY);
 
     this.matrix = fromObject(event.matrix);
 
-    this.observer && this.observer.update(offsetX);
+    this.observer && this.observer.update(event.offsetX);
 
     this.props.onZoomPan({
       scale: this.props.scale,
-      offsetX,
-      offsetY,
+      offsetX: event.offsetX,
+      offsetY: event.offsetY,
       type: 'pan'
     });
   }
@@ -124,7 +124,7 @@ export class ZoomPan extends Component<ZoomPanProps, ZoomPanState> {
     if (false) {
     // if (this.observer && this.props.decay) {
       const end = this.getEndOffset();
-      const constrained = this.props.constrained;
+      const constrained = this.props.constrain;
 
       this.decay = decay({
         from: this.observer.get(),
@@ -158,14 +158,14 @@ export class ZoomPan extends Component<ZoomPanProps, ZoomPanState> {
     this.stopDecay();
     const inRange = this.ensureRange(event.offsetX);
 
-    if (inRange) {
+    // if (inRange) {
       this.matrix = fromObject(event.matrix);
 
       this.props.onZoomPan({
         ...event,
         type: 'zoom'
       });
-    }
+    // }
   }
 
   onZoomEnd() {
@@ -187,7 +187,8 @@ export class ZoomPan extends Component<ZoomPanProps, ZoomPanState> {
       scale,
       offsetX,
       offsetY,
-      disableMouseWheel
+      disableMouseWheel,
+      constrain
     } = this.props;
     const { isZooming, isPanning } = this.state;
     const cursor = pannable ? 'move' : 'auto';
@@ -200,6 +201,9 @@ export class ZoomPan extends Component<ZoomPanProps, ZoomPanState> {
         offsetY={offsetY}
         scale={scale}
         matrix={matrix}
+        constrain={constrain}
+        height={height}
+        width={width}
         disabled={!pannable || disabled}
         onPanStart={bind(this.onPanStart, this)}
         onPanMove={bind(this.onPanMove, this)}

--- a/src/common/ZoomPan/ZoomPan.tsx
+++ b/src/common/ZoomPan/ZoomPan.tsx
@@ -211,9 +211,6 @@ export class ZoomPan extends Component<ZoomPanProps, ZoomPanState> {
             scale={scale}
             x={x}
             y={y}
-            constrain={constrain}
-            height={height}
-            width={width}
             onZoom={bind(this.onZoom, this)}
             onZoomEnd={bind(this.onZoomEnd, this)}
             matrix={matrix}

--- a/src/common/utils/position.tsx
+++ b/src/common/utils/position.tsx
@@ -127,3 +127,22 @@ export function getPointFromMouse(node, event?) {
     clientY
   });
 }
+
+/**
+ * Constrain the matrix.
+ */
+export function constrainMatrix(height: number, width: number, matrix) {
+  const limitX = width * matrix.a - width;
+  const limitY = height * matrix.a - height;
+
+  const { x, y } = applyToPoint(matrix, { x: 0, y: 0 });
+  if ((-x > limitX) || (-x <= 0)) {
+    return false;
+  }
+
+  if ((-y > limitY) || (-y <= 0)) {
+    return false;
+  }
+
+  return true;
+}

--- a/src/common/utils/position.tsx
+++ b/src/common/utils/position.tsx
@@ -48,3 +48,50 @@ export function getClosestPoint(pos: number, scale, data, attr = 'x') {
 
   return beforeVal < afterVal ? before : after;
 }
+
+
+export function localPoint(node, event?) {
+  // called with no args
+  if (!node) return;
+
+  // called with localPoint(event)
+  if (node.target) {
+    event = node;
+
+    // set node to targets owner svg
+    node = event.target.ownerSVGElement;
+
+    // find the outermost svg
+    while (node.ownerSVGElement) {
+      node = node.ownerSVGElement;
+    }
+  }
+
+  // default to mouse event
+  let { clientX, clientY } = event;
+
+  // support touch event
+  if (event.changedTouches) {
+    clientX = event.changedTouches[0].clientX;
+    clientY = event.changedTouches[0].clientY;
+  }
+
+  // calculate coordinates from svg
+  if (node.createSVGPoint) {
+    let point = node.createSVGPoint();
+    point.x = clientX;
+    point.y = clientY;
+    point = point.matrixTransform(node.getScreenCTM().inverse());
+    return {
+      x: point.x,
+      y: point.y
+    };
+  }
+
+  // fallback to calculating position from non-svg dom node
+  const rect = node.getBoundingClientRect();
+  return {
+    x: clientX - rect.left - node.clientLeft,
+    y: clientY - rect.top - node.clientTop
+  };
+}

--- a/src/common/utils/position.tsx
+++ b/src/common/utils/position.tsx
@@ -1,4 +1,5 @@
 import { bisector } from 'd3-array';
+import { applyToPoint, inverse } from 'transformation-matrix';
 
 /**
  * Given a point position, get the closes data point in the dataset.
@@ -88,6 +89,21 @@ export function getPointFromTouch(node, event?) {
     });
   })
 }
+
+/**
+ * Gets the point from q given matrix.
+*/
+export function getPointFromMatrix(event, matrix) {
+  const parent = getParentSVG(event);
+
+  // Determines client coordinates relative to the editor component
+  const rect = parent.getBoundingClientRect();
+  const relativeClientX = event.clientX - rect.left;
+  const relativeClientY = event.clientY - rect.top;
+
+  // Transforms the coordinate to world coordinate (in the SVG/DIV world)
+  return applyToPoint(inverse(matrix), {x: relativeClientX, y: relativeClientY});
+};
 
 /**
  * Get the point given a node.

--- a/src/common/utils/position.tsx
+++ b/src/common/utils/position.tsx
@@ -55,28 +55,6 @@ export function getPositionForTarget({ target, clientX, clientY }) {
 }
 
 /**
- * Get the point from a touch event.
- */
-export function getPointFromTouch(node, event?) {
-  // called with no args
-  if (!node) return;
-
-  // called with localPoint(event)
-  if (node.target) {
-    event = node;
-    node = getParentSVG(node);
-  }
-
-  return [...event.touches].map(touch => {
-    return getPositionForTarget({
-      target: node,
-      clientX: touch.clientX,
-      clientY: touch.clientY
-    });
-  });
-}
-
-/**
  * Gets the point from q given matrix.
 */
 export function getPointFromMatrix(event, matrix) {


### PR DESCRIPTION
This PR completely redoes the panning/zooming. It also fixes an issue when tooltips would disappear on click for charts.

Couple of things I want to revisit:
- Due to all the panning changes, it could no longer generically be used. As a result, I had to duplicate a lot of code for brushes and they also lost touch ability as a result.
- Need to go back through and add better types
- The brush code could use some revisiting for change detection cleanup
- I noticed that cursors don't work on brushes, need to revisit when i do the refactor