### PR TITLE
Pie Explosion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.7.0
+- [Feature] Add ability to explode pie charts
+
 # 2.6.5
 - [Fix] Fix area/line not pulling colors correctly
 

--- a/src/PieChart/PieArcSeries/PieArcLabel/PieArcLabel.tsx
+++ b/src/PieChart/PieArcSeries/PieArcLabel/PieArcLabel.tsx
@@ -4,9 +4,7 @@ import { PosedArcLabelGroup } from './PosedArcLabelGroup';
 
 export interface PieArcLabelProps {
   data: any;
-  innerArc: any;
-  show: boolean;
-  outerArc: any;
+  centroid: any;
   format?: (v) => any;
   fontFill: string;
   fontSize: number;
@@ -21,7 +19,6 @@ const getTextAnchor = ({ startAngle, endAngle }) =>
 
 export class PieArcLabel extends PureComponent<PieArcLabelProps> {
   static defaultProps: Partial<PieArcLabelProps> = {
-    show: false,
     format: undefined,
     lineStroke: 'rgba(127,127,127,0.5)',
     fontFill: '#8F979F',
@@ -32,7 +29,7 @@ export class PieArcLabel extends PureComponent<PieArcLabelProps> {
 
   render() {
     const {
-      innerArc,
+      centroid,
       data,
       lineStroke,
       padding,
@@ -47,7 +44,7 @@ export class PieArcLabel extends PureComponent<PieArcLabelProps> {
     const textAnchor = getTextAnchor(data);
     const [posX, posY] = position;
 
-    const innerLinePos = innerArc.centroid(data);
+    const innerLinePos = centroid(data);
     let scale = posY / innerLinePos[1];
     if (posY === 0 || innerLinePos[1] === 0) {
       scale = 1;

--- a/src/PieChart/PieChart.story.tsx
+++ b/src/PieChart/PieChart.story.tsx
@@ -15,7 +15,22 @@ storiesOf('Charts/Pie/Pie', module)
       series={
         <PieArcSeries
           colorScheme={chroma
-            .scale(['#ACB7C9', '#418AD7'])
+            .scale(['#4dd0e1', '#1976d2'])
+            .colors(categoryData.length)}
+        />
+      }
+    />
+  ))
+  .add('Explode', () => (
+    <PieChart
+      width={350}
+      height={250}
+      data={categoryData}
+      series={
+        <PieArcSeries
+          explode={true}
+          colorScheme={chroma
+            .scale(['#4dd0e1', '#1976d2'])
             .colors(categoryData.length)}
         />
       }
@@ -28,9 +43,8 @@ storiesOf('Charts/Pie/Pie', module)
       data={browserData}
       series={
         <PieArcSeries
-          label={<PieArcLabel show={true} />}
           colorScheme={chroma
-            .scale(['#ACB7C9', '#418AD7'])
+            .scale(['#4dd0e1', '#1976d2'])
             .colors(browserData.length)}
         />
       }
@@ -53,7 +67,7 @@ storiesOf('Charts/Pie/Donut', module)
         <PieArcSeries
           doughnut={true}
           colorScheme={chroma
-            .scale(['#ACB7C9', '#418AD7'])
+            .scale(['#4dd0e1', '#1976d2'])
             .colors(categoryData.length)}
         />
       }
@@ -68,9 +82,8 @@ storiesOf('Charts/Pie/Donut', module)
         <PieArcSeries
           doughnut={true}
           colorScheme={chroma
-            .scale(['#ACB7C9', '#418AD7'])
+            .scale(['#4dd0e1', '#1976d2'])
             .colors(categoryData.length)}
-          label={<PieArcLabel show={true} />}
         />
       }
     />
@@ -94,14 +107,15 @@ storiesOf('Charts/Pie/Donut', module)
           series={
             <PieArcSeries
               doughnut={true}
+              label={null}
               colorScheme={chroma
-                .scale(['#ACB7C9', '#418AD7'])
+                .scale(['#4dd0e1', '#1976d2'])
                 .colors(categoryData.length)}
             />
           }
         />
       </div>
-      <h1 style={{ margin: '0 5px', padding: 0 }}>
+      <h1 style={{ margin: '0 5px', padding: 0, color: 'white' }}>
         {categoryData.length} Attacks
       </h1>
     </div>

--- a/src/PieChart/PieChart.tsx
+++ b/src/PieChart/PieChart.tsx
@@ -34,8 +34,7 @@ export class PieChart extends Component<PieChartProps, {}> {
 
   getData = memoize((data: ChartDataShape[]) => {
     const pieLayout = pie()
-      .value((d: any) => d.data)
-      .sort(null);
+      .value((d: any) => d.data);
 
     return pieLayout(data as any);
   });


### PR DESCRIPTION
This PR:

- adds the ability to explode the values of a pie chart
- applies sorting to pie values
- removes un-needed `show` prop on labels

![2019-08-20_16-16-23](https://user-images.githubusercontent.com/227909/63381309-6760fa00-c366-11e9-8424-fe4528837c0e.png)
