### PR TITLE
Heat improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Master
-- [Feature] Calendar Heatmap
+- [Feature] Year/Month Calendar Heatmaps
 - [Fix] Fix `meta` for deep values not being passed correctly
 
 # 2.9.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Master
-- [Feature] Year/Month Calendar Heatmaps
+- [Feature] Year Calendar Heatmaps
+- [Feature] Month Calendar Heatmaps
+- [Feature] Add ability to pass empty heatmap colors
+- [Feature] Add ability to pass empty heatmap color
+- [Feature] Expose `cell` in `series` of heatmap
+- [Feature] Add ability to pass style/class callbacks to heatmap `cell`
+- [Fix] Update domain ranges to `range` from `rangeRound` in heatmap
+- [Fix] Tweak tooltip offsets for heatmaps
 - [Fix] Fix `meta` for deep values not being passed correctly
+- [Fix] Update `LinearAxisProps`'s `domain` to accept n number of domains
 
 # 2.9.5
 - [Fix] Fix wrong element selector for `globalPanning` determination

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Master
+- [Feature] Calendar Heatmap
+- [Fix] Fix `meta` for deep values not being passed correctly
+
 # 2.9.5
 - [Fix] Fix wrong element selector for `globalPanning` determination
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ Chart types include:
 - Map Chart
 - Heatmap
   - Standard
-  - Calendar
+  - Year Calendar
+  - Month Calendar
 
 Additional features:
 

--- a/README.md
+++ b/README.md
@@ -33,30 +33,69 @@ creating charts without sacrificing customization ability.
 
 Chart types include:
 
-- Linear (Vertical & Horizontal) & Radial Bar Chart
-- Linear & Radial Line Chart
-- Linear & Radial Area Chart
-- Linear & Radial Bubble Chart
-- Linear & Radial Scatter Plot
+- Bar Chart
+  - Single Series Vertical / Horizontal
+  - Multi Series Vertical / Horizontal
+  - Stacked Vertical / Horizontal
+  - Stacked Normalized Vertical / Horizontal
+  - Stacked Diverging Vertical / Horizontal
+  - Marimekko
+  - Radial
+  - Sparkline
+- Line Chart
+  - Single Series
+  - Multi Series
+  - Stacked
+  - Stacked Normalized
+  - Radial
+  - Sparklines
+- Area Chart
+  - Single Series
+  - Multi Series
+  - Stacked
+  - Stacked Normalized
+  - Radial
+  - Sparklines
+- Bubble Chart
+  - Linear
+  - Radial
+- Scatter Chart
+  - Linear
+  - Radial
 - Pie Chart
+  - Standard
+  - Exploded
+- Donut Chart
+- Sankey chart
 - Hive Plot
-- Sankey Chart
-- Map Chart
-- Sparklines
 - Radial Gauge Chart
+- Map Chart
+- Heatmap
+  - Standard
+  - Calendar
 
 Additional features:
 
-- Legend
+- Legends
 - Tooltips
 - Animations Enter/Update/Exit
-- Linear & Radial Axis
-- Brush
-- Patterns & Gradients Styles
-- Panning/Zooming
+- Axis
+  - Linear
+  - Radial
+  - Advanced Label Positioning
 - Gestures
-- Grid/Marklines
+  - Pinch
+  - Pan
+  - Zoom
+  - Move
+- Brush
+- Patterns
+- Gradients
+- Grid Lines
+- Mark Lines
 - BigInt Support
+- Auto Sizing
+- Range Lines
 
 ## 📦 Install
 

--- a/demo/heatmap.ts
+++ b/demo/heatmap.ts
@@ -1,3 +1,7 @@
+import { generateDate, randomNumber } from './utils';
+import { range } from 'd3-array';
+import moment from 'moment';
+
 export const heatmapSimpleData = [
   {
     key: 'Lateral Movement',
@@ -97,3 +101,8 @@ export const heatmapSimpleData = [
     ]
   }
 ];
+
+export const heatmapCalendarData = range(365).map(i => ({
+  key: moment().startOf('year').add(i, 'days').toDate(),
+  data: randomNumber(0, 50)
+}));

--- a/demo/heatmap.ts
+++ b/demo/heatmap.ts
@@ -7,6 +7,10 @@ export const heatmapSimpleData = [
     key: 'Lateral Movement',
     data: [
       {
+        key: 'XML',
+        data: 0
+      },
+      {
         key: 'JSON',
         data: 120
       },
@@ -30,6 +34,10 @@ export const heatmapSimpleData = [
       {
         key: 'JSON',
         data: 34
+      },
+      {
+        key: 'HTTPS',
+        data: 0
       },
       {
         key: 'SSH',

--- a/demo/heatmap.ts
+++ b/demo/heatmap.ts
@@ -1,4 +1,4 @@
-import { generateDate, randomNumber } from './utils';
+import { randomNumber } from './utils';
 import { range } from 'd3-array';
 import moment from 'moment';
 

--- a/demo/heatmap.ts
+++ b/demo/heatmap.ts
@@ -110,7 +110,24 @@ export const heatmapSimpleData = [
   }
 ];
 
+const yearStart = moment().startOf('year');
+
 export const heatmapCalendarData = range(365).map(i => ({
-  key: moment().startOf('year').add(i, 'days').toDate(),
+  key: yearStart.clone().add(i, 'days').toDate(),
+  data: randomNumber(0, 50)
+}));
+
+export const janHeatMapData = range(31).map(i => ({
+  key: yearStart.clone().add(i, 'days').toDate(),
+  data: randomNumber(0, 50)
+}));
+
+export const febHeatMapData = range(28).map(i => ({
+  key: yearStart.clone().add(1, 'month').add(i, 'days').toDate(),
+  data: randomNumber(0, 50)
+}));
+
+export const marchHeatMapData = range(31).map(i => ({
+  key: yearStart.clone().add(2, 'month').add(i, 'days').toDate(),
   data: randomNumber(0, 50)
 }));

--- a/src/BarChart/BarSeries/Bar.tsx
+++ b/src/BarChart/BarSeries/Bar.tsx
@@ -76,9 +76,9 @@ export class Bar extends Component<BarProps, BarState> {
   state: BarState = {};
 
   getExit({ x, y, width, height }: BarCoordinates) {
-    const { yScale, layout, xScale } = this.props;
+    const { yScale, xScale } = this.props;
 
-    const isVertical = layout === 'vertical';
+    const isVertical = this.getIsVertical();
     const newX = isVertical ? x : Math.min(...xScale.range());
     const newY = isVertical ? Math.max(...yScale.range()) : y;
     const newHeight = isVertical ? 0 : height;

--- a/src/Heatmap/CalendarHeatmap.tsx
+++ b/src/Heatmap/CalendarHeatmap.tsx
@@ -14,16 +14,12 @@ import { group, range, sum } from 'd3-array';
 import { memoize } from 'lodash-es';
 import { HeatmapSeries } from './HeatmapSeries';
 
-export type CalendarHeatmapView = 'year' | 'month' | 'day';
-
 export interface CalendarHeatmapProps extends Omit<HeatmapProps, 'data'> {
   data: ChartShallowDataShape[];
-  view: CalendarHeatmapView;
 }
 
 export class CalendarHeatmap extends Component<CalendarHeatmapProps> {
   static defaultProps: Partial<CalendarHeatmapProps> = {
-    view: 'year',
     series: <HeatmapSeries padding={0.3} />
   };
 
@@ -55,8 +51,6 @@ export class CalendarHeatmap extends Component<CalendarHeatmapProps> {
     const yDomain = moment.weekdaysShort().reverse();
     const xDomain = range(52);
 
-    console.log('here', newData);
-
     return {
       data: newData,
       yDomain,
@@ -65,7 +59,7 @@ export class CalendarHeatmap extends Component<CalendarHeatmapProps> {
   });
 
   render() {
-    const { data, view, ...rest } = this.props;
+    const { data, ...rest } = this.props;
     const { data: calData, yDomain, xDomain } = this.getDataDomains(data);
 
     return (

--- a/src/Heatmap/CalendarHeatmap.tsx
+++ b/src/Heatmap/CalendarHeatmap.tsx
@@ -46,6 +46,10 @@ export class CalendarHeatmap extends Component<CalendarHeatmapProps> {
   getDataDomains = memoize((rawData: ChartShallowDataShape[]) => {
     const start = moment().startOf('year');
     const end = moment().endOf('year');
+
+    const yDomain = moment.weekdaysShort().reverse();
+    const xDomain = range(52);
+
     const dates = rawData
       .filter(
         d =>
@@ -66,6 +70,8 @@ export class CalendarHeatmap extends Component<CalendarHeatmapProps> {
           data: sum(nestedData, d => d.data)
         })),
         meta: {
+          start: start.toDate(),
+          end: end.toDate(),
           date: start
             .clone()
             .add(key, 'weeks')
@@ -73,9 +79,6 @@ export class CalendarHeatmap extends Component<CalendarHeatmapProps> {
         }
       })
     );
-
-    const yDomain = moment.weekdaysShort().reverse();
-    const xDomain = range(52);
 
     return {
       data,

--- a/src/Heatmap/CalendarHeatmap.tsx
+++ b/src/Heatmap/CalendarHeatmap.tsx
@@ -49,8 +49,8 @@ export class CalendarHeatmap extends Component<CalendarHeatmapProps> {
 
   getDataDomains = memoize((rawData: ChartShallowDataShape[]) => {
     // Build our x/y domains for days of week + number of weeks in year
-    const yDomain = range(6).reverse();
-    const xDomain = range(51);
+    const yDomain = range(7).reverse();
+    const xDomain = range(53);
 
     // Get the most recent date to get the range from
     // From the end date, lets find the start year of that
@@ -76,7 +76,7 @@ export class CalendarHeatmap extends Component<CalendarHeatmapProps> {
     const curDate = start.clone().subtract(firstDayOfYear, 'days');
     const rows = [];
 
-    for (let week = 0; week <= 51; week++) {
+    for (let week = 0; week <= 52; week++) {
       const row = {
         key: week,
         data: []
@@ -100,8 +100,6 @@ export class CalendarHeatmap extends Component<CalendarHeatmapProps> {
 
       rows.push(row);
     }
-
-    console.log('raw', rows);
 
     return {
       data: rows,
@@ -146,6 +144,7 @@ export class CalendarHeatmap extends Component<CalendarHeatmapProps> {
                 label={
                   <LinearXAxisTickLabel
                     padding={5}
+                    align="end"
                     format={d =>
                       moment()
                         .startOf('year')

--- a/src/Heatmap/CalendarHeatmap.tsx
+++ b/src/Heatmap/CalendarHeatmap.tsx
@@ -1,0 +1,115 @@
+import React, { Component } from 'react';
+import { ChartShallowDataShape } from '../common/data';
+import { Heatmap, HeatmapProps } from './Heatmap';
+import moment from 'moment';
+import {
+  LinearXAxis,
+  LinearYAxis,
+  LinearYAxisTickSeries,
+  LinearXAxisTickSeries,
+  LinearYAxisTickLabel,
+  LinearXAxisTickLabel
+} from '../common/Axis';
+import { group, range, sum } from 'd3-array';
+import { memoize } from 'lodash-es';
+import { HeatmapSeries } from './HeatmapSeries';
+
+export type CalendarHeatmapView = 'year' | 'month' | 'day';
+
+export interface CalendarHeatmapProps extends Omit<HeatmapProps, 'data'> {
+  data: ChartShallowDataShape[];
+  view: CalendarHeatmapView;
+}
+
+export class CalendarHeatmap extends Component<CalendarHeatmapProps> {
+  static defaultProps: Partial<CalendarHeatmapProps> = {
+    view: 'year',
+    series: <HeatmapSeries padding={0.3} />
+  };
+
+  getDataDomains = memoize((data: ChartShallowDataShape[]) => {
+    const start = moment().startOf('year');
+    const end = moment().endOf('year');
+    const dates = data
+      .filter(
+        d =>
+          moment(d.key as Date).isAfter(start) &&
+          moment(d.key as Date).isBefore(end)
+      )
+      .map(d => ({
+        key: moment(d.key as Date).startOf('day'),
+        data: d.data
+      }));
+
+    const newData = Array.from(
+      group(dates, d => parseInt(d.key.format('w')), d => d.key.format('ddd')),
+      ([key, weekData]) => ({
+        key,
+        data: Array.from(weekData, ([nestedKey, nestedData]) => ({
+          key: nestedKey,
+          data: sum(nestedData, d => d.data)
+        }))
+      })
+    );
+
+    const yDomain = moment.weekdaysShort().reverse();
+    const xDomain = range(52);
+
+    console.log('here', newData);
+
+    return {
+      data: newData,
+      yDomain,
+      xDomain
+    };
+  });
+
+  render() {
+    const { data, view, ...rest } = this.props;
+    const { data: calData, yDomain, xDomain } = this.getDataDomains(data);
+
+    return (
+      <Heatmap
+        {...rest}
+        data={calData}
+        yAxis={
+          <LinearYAxis
+            type="category"
+            axisLine={null}
+            domain={yDomain}
+            tickSeries={
+              <LinearYAxisTickSeries
+                tickSize={22}
+                line={null}
+                label={<LinearYAxisTickLabel padding={5} />}
+              />
+            }
+          />
+        }
+        xAxis={
+          <LinearXAxis
+            type="category"
+            axisLine={null}
+            domain={xDomain}
+            tickSeries={
+              <LinearXAxisTickSeries
+                line={null}
+                label={
+                  <LinearXAxisTickLabel
+                    padding={5}
+                    format={d =>
+                      moment()
+                        .startOf('year')
+                        .add(d, 'weeks')
+                        .format('MMMM')
+                    }
+                  />
+                }
+              />
+            }
+          />
+        }
+      />
+    );
+  }
+}

--- a/src/Heatmap/CalendarHeatmap.tsx
+++ b/src/Heatmap/CalendarHeatmap.tsx
@@ -49,8 +49,8 @@ export class CalendarHeatmap extends Component<CalendarHeatmapProps> {
 
   getDataDomains = memoize((rawData: ChartShallowDataShape[]) => {
     // Build our x/y domains for days of week + number of weeks in year
-    const yDomain = range(7).reverse();
-    const xDomain = range(52);
+    const yDomain = range(6).reverse();
+    const xDomain = range(51);
 
     // Get the most recent date to get the range from
     // From the end date, lets find the start year of that
@@ -72,51 +72,36 @@ export class CalendarHeatmap extends Component<CalendarHeatmapProps> {
         data: d.data
       }));
 
-    // Group the dates by:
-    //  - Week Number of Year - Example: 52
-    //  - Day of Week Short Name - Example: 4
-    //  - Sum of Values for that Day of Week - Example: 5
+    const firstDayOfYear = start.weekday();
+    const curDate = start.clone().subtract(firstDayOfYear, 'days');
     const rows = [];
-    for (const week of xDomain) {
+
+    for (let week = 0; week <= 51; week++) {
       const row = {
         key: week,
         data: []
       };
 
-      const weekDate = start.clone().add(week, 'weeks');
+      for (let day = 0; day <= 6; day++) {
+        const dayValue = dates.find(d => d.key.isSame(curDate));
 
-      for (const day of yDomain) {
-        const dayDate = weekDate.clone().add(day, 'days');
-        const dayNum = dayDate.day();
-        const dayValue = dates.find(d => d.key.isSame(dayDate));
+        row.data.push({
+          key: day,
+          data: dayValue ? dayValue.data : undefined,
+          meta: {
+            date: curDate.clone().toDate(),
+            start: start.toDate(),
+            end: end.toDate()
+          }
+        });
 
-        if (dayValue) {
-          row.data[dayNum] = {
-            key: dayNum,
-            data: dayValue ? dayValue.data : undefined,
-            meta: {
-              date: dayDate.toDate(),
-              start: start.toDate(),
-              end: end.toDate()
-            }
-          };
-        } else {
-          row.data[dayNum] = {
-            key: dayNum,
-            data: 0,
-            meta: {
-              date: dayDate.toDate(),
-              start: start.toDate(),
-              end: end.toDate()
-            }
-          };
-        }
+        curDate.add(1, 'day');
       }
 
       rows.push(row);
     }
 
-    console.log('here', rows);
+    console.log('raw', rows);
 
     return {
       data: rows,

--- a/src/Heatmap/Heatmap.story.tsx
+++ b/src/Heatmap/Heatmap.story.tsx
@@ -8,6 +8,4 @@ storiesOf('Charts/Heatmap', module)
   .add('Basic', () => (
     <Heatmap height={250} width={400} data={heatmapSimpleData} />
   ))
-  .add('Calendar', () => (
-    <CalendarHeatmap height={115} width={715} data={heatmapCalendarData} />
-  ));
+  .add('Calendar', () => <CalendarHeatmap data={heatmapCalendarData} />);

--- a/src/Heatmap/Heatmap.story.tsx
+++ b/src/Heatmap/Heatmap.story.tsx
@@ -2,10 +2,48 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { Heatmap } from './Heatmap';
 import { CalendarHeatmap } from './CalendarHeatmap';
-import { heatmapSimpleData, heatmapCalendarData } from '../../demo';
+import {
+  heatmapSimpleData,
+  heatmapCalendarData,
+  janHeatMapData,
+  febHeatMapData,
+  marchHeatMapData
+} from '../../demo';
 
 storiesOf('Charts/Heatmap', module)
   .add('Basic', () => (
     <Heatmap height={250} width={400} data={heatmapSimpleData} />
   ))
-  .add('Calendar', () => <CalendarHeatmap data={heatmapCalendarData} />);
+  .add('Year Calendar', () => (
+    <CalendarHeatmap height={115} width={715} data={heatmapCalendarData} />
+  ))
+  .add('Month Calendar', () => (
+    <CalendarHeatmap
+      height={115}
+      width={100}
+      view="month"
+      data={janHeatMapData}
+    />
+  ))
+  .add('Multi Month Calendar', () => (
+    <div style={{ display: 'flex' }}>
+      <CalendarHeatmap
+        height={115}
+        width={100}
+        view="month"
+        data={janHeatMapData}
+      />
+      <CalendarHeatmap
+        height={115}
+        width={100}
+        view="month"
+        data={febHeatMapData}
+      />
+      <CalendarHeatmap
+        height={115}
+        width={100}
+        view="month"
+        data={marchHeatMapData}
+      />
+    </div>
+  ));

--- a/src/Heatmap/Heatmap.story.tsx
+++ b/src/Heatmap/Heatmap.story.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { Heatmap } from './Heatmap';
-import { heatmapSimpleData } from '../../demo';
+import { CalendarHeatmap } from './CalendarHeatmap';
+import { heatmapSimpleData, heatmapCalendarData } from '../../demo';
 
-storiesOf('Charts/Heatmap', module).add('Basic', () => (
-  <Heatmap height={250} width={400} data={heatmapSimpleData} />
-));
+storiesOf('Charts/Heatmap', module)
+  .add('Basic', () => (
+    <Heatmap height={250} width={400} data={heatmapSimpleData} />
+  ))
+  .add('Calendar', () => (
+    <CalendarHeatmap height={115} width={715} data={heatmapCalendarData} />
+  ));

--- a/src/Heatmap/Heatmap.tsx
+++ b/src/Heatmap/Heatmap.tsx
@@ -67,14 +67,14 @@ export class Heatmap extends Component<HeatmapProps> {
 
     const xDomain = xAxis.props.domain || uniqueBy(data, d => d.key);
     const xScale = scaleBand()
-      .rangeRound([0, chartWidth])
+      .range([0, chartWidth])
       .domain(xDomain)
       .paddingInner(series.props.padding);
 
     const yDomain = yAxis.props.domain || uniqueBy(data, d => d.data, d => d.x);
     const yScale = scaleBand()
       .domain(yDomain)
-      .rangeRound([chartHeight, 0])
+      .range([chartHeight, 0])
       .paddingInner(series.props.padding);
 
     return {

--- a/src/Heatmap/Heatmap.tsx
+++ b/src/Heatmap/Heatmap.tsx
@@ -22,7 +22,7 @@ import { HeatmapSeries, HeatmapSeriesProps } from './HeatmapSeries';
 import { scaleBand } from 'd3-scale';
 import { uniqueBy } from '../common/utils/array';
 
-interface HeatmapProps extends ChartProps {
+export interface HeatmapProps extends ChartProps {
   data: ChartNestedDataShape[];
   series: JSX.Element;
   yAxis: JSX.Element;

--- a/src/Heatmap/HeatmapCell.tsx
+++ b/src/Heatmap/HeatmapCell.tsx
@@ -3,8 +3,12 @@ import { ChartTooltip, ChartTooltipProps } from '../common/TooltipArea';
 import { CloneElement } from '../common/utils/children';
 import bind from 'memoize-bind';
 import { PosedCell } from './PosedCell';
+import {
+  constructFunctionProps,
+  PropFunctionTypes
+} from '../common/utils/functions';
 
-export interface HeatmapCellProps {
+export type HeatmapCellProps = {
   x: number;
   y: number;
   rx: number;
@@ -16,10 +20,11 @@ export interface HeatmapCellProps {
   data: any;
   animated: boolean;
   cellIndex: number;
+  cursor: string;
   onClick: (event) => void;
   onMouseEnter: (event) => void;
   onMouseLeave: (event) => void;
-}
+} & PropFunctionTypes;
 
 interface HeatmapCellState {
   active?: boolean;
@@ -29,6 +34,7 @@ export class HeatmapCell extends Component<HeatmapCellProps, HeatmapCellState> {
   static defaultProps: Partial<HeatmapCellProps> = {
     rx: 2,
     ry: 2,
+    cursor: 'auto',
     tooltip: <ChartTooltip />,
     onClick: () => undefined,
     onMouseEnter: () => undefined,
@@ -83,9 +89,12 @@ export class HeatmapCell extends Component<HeatmapCellProps, HeatmapCellState> {
       onMouseLeave,
       onClick,
       cellIndex,
+      data,
+      cursor,
       ...rest
     } = this.props;
     const { active } = this.state;
+    const extras = constructFunctionProps(this.props, data);
 
     return (
       <Fragment>
@@ -93,6 +102,8 @@ export class HeatmapCell extends Component<HeatmapCellProps, HeatmapCellState> {
           {...rest}
           ref={this.rect}
           index={cellIndex}
+          style={{ ...extras.style, cursor }}
+          className={extras.className}
           onMouseEnter={bind(this.onMouseEnter, this)}
           onMouseLeave={bind(this.onMouseLeave, this)}
           onClick={bind(this.onMouseClick, this)}

--- a/src/Heatmap/HeatmapCell.tsx
+++ b/src/Heatmap/HeatmapCell.tsx
@@ -30,6 +30,13 @@ interface HeatmapCellState {
   active?: boolean;
 }
 
+// Set padding modifier for the tooltips
+const modifiers = {
+  offset: {
+    offset: '0, 3px'
+  }
+};
+
 export class HeatmapCell extends Component<HeatmapCellProps, HeatmapCellState> {
   static defaultProps: Partial<HeatmapCellProps> = {
     rx: 2,
@@ -113,6 +120,7 @@ export class HeatmapCell extends Component<HeatmapCellProps, HeatmapCellState> {
           <CloneElement<ChartTooltipProps>
             element={tooltip}
             visible={!!active}
+            modifiers={tooltip.props.modifiers || modifiers}
             reference={this.rect}
             value={this.getTooltipData()}
           />

--- a/src/Heatmap/HeatmapCell.tsx
+++ b/src/Heatmap/HeatmapCell.tsx
@@ -78,7 +78,8 @@ export class HeatmapCell extends Component<HeatmapCellProps, HeatmapCellState> {
 
     return {
       y: data.value,
-      x: `${data.key} ∙ ${data.x}`
+      x: `${data.key} ∙ ${data.x}`,
+      metadata: data
     };
   }
 

--- a/src/Heatmap/HeatmapSeries.tsx
+++ b/src/Heatmap/HeatmapSeries.tsx
@@ -1,11 +1,12 @@
 import React, { Component } from 'react';
-import { HeatmapCell } from './HeatmapCell';
+import { HeatmapCell, HeatmapCellProps } from './HeatmapCell';
 import { scaleQuantile } from 'd3-scale';
 import { uniqueBy } from '../common/utils/array';
 import { extent } from 'd3-array';
 import { PoseGroup } from 'react-pose';
 import { PoseSVGGElement } from 'common/utils/animations';
 import { memoize } from 'lodash-es';
+import { CloneElement } from '../common/utils/children';
 
 export interface HeatmapSeriesProps {
   padding: number;
@@ -15,60 +16,53 @@ export interface HeatmapSeriesProps {
   yScale: any;
   colorScheme: any;
   animated: boolean;
+  cell: JSX.Element;
 }
 
 export class HeatmapSeries extends Component<HeatmapSeriesProps> {
   static defaultProps: Partial<HeatmapSeriesProps> = {
     padding: 0.1,
     animated: true,
-    colorScheme: ['#1d6b56', '#2da283']
+    colorScheme: ['rgba(28, 107, 86, 0.5)', '#2da283'],
+    cell: <HeatmapCell />
   };
 
   getValueScale = memoize((data, colorScheme) => {
     const valueDomain = extent(uniqueBy(data, d => d.data, d => d.value));
 
-    return scaleQuantile<string>()
-      .domain(valueDomain)
-      .range(colorScheme);
+    return point => {
+      // For 0 values, lets show a placeholder fill
+      if (point === 0 || point === undefined || point === null) {
+        return 'rgba(200,200,200,0.08)';
+      }
+
+      return scaleQuantile<string>()
+        .domain(valueDomain)
+        .range(colorScheme)(point);
+    };
   });
 
-  renderEmptySeries(width, height) {
-    const { xScale, yScale, id } = this.props;
-    const xDomain = xScale.domain();
-    const yDomain = yScale.domain();
-
-    return xDomain.map(x =>
-      yDomain.map((y, i) => (
-        <PoseSVGGElement key={`${id}-${x}-${y}`}>
-          <HeatmapCell
-            animated={false}
-            cellIndex={i}
-            fill="rgba(200,200,200,0.08)"
-            x={xScale(x)}
-            y={yScale(y)}
-            width={width}
-            height={height}
-            data={{ x: y, key: x, value: 0 }}
-          />
-        </PoseSVGGElement>
-      ))
-    );
-  }
-
   render() {
-    const { xScale, yScale, data, id, colorScheme, animated } = this.props;
+    const {
+      xScale,
+      yScale,
+      data,
+      id,
+      colorScheme,
+      animated,
+      cell
+    } = this.props;
     const valueScale = this.getValueScale(data, colorScheme);
-
     const height = yScale.bandwidth();
     const width = xScale.bandwidth();
 
     return (
       <PoseGroup animateOnMount={animated}>
-        {this.renderEmptySeries(width, height)}
         {data.map((pair, i) =>
           pair.data.map((val, ii) => (
             <PoseSVGGElement key={`${id}-${i}-${ii}`}>
-              <HeatmapCell
+              <CloneElement<HeatmapCellProps>
+                element={cell}
                 animated={animated}
                 cellIndex={i + ii}
                 x={xScale(pair.key)}

--- a/src/Heatmap/HeatmapSeries.tsx
+++ b/src/Heatmap/HeatmapSeries.tsx
@@ -42,38 +42,51 @@ export class HeatmapSeries extends Component<HeatmapSeriesProps> {
     };
   });
 
+  renderCell({ row, cell, rowIndex, cellIndex, valueScale, width, height }) {
+    const { xScale, yScale, id, animated, cell: cellElement } = this.props;
+
+    const x = xScale(row.key);
+    const y = yScale(cell.x);
+    const fill = valueScale(cell.value);
+
+    return (
+      <PoseSVGGElement key={`${id}-${rowIndex}-${cellIndex}`}>
+        <CloneElement<HeatmapCellProps>
+          element={cellElement}
+          animated={animated}
+          cellIndex={rowIndex + cellIndex}
+          x={x}
+          y={y}
+          fill={fill}
+          width={width}
+          height={height}
+          data={cell}
+        />
+      </PoseSVGGElement>
+    );
+  }
+
   render() {
-    const {
-      xScale,
-      yScale,
-      data,
-      id,
-      colorScheme,
-      animated,
-      cell
-    } = this.props;
+    const { xScale, yScale, data, colorScheme, animated } = this.props;
+
     const valueScale = this.getValueScale(data, colorScheme);
     const height = yScale.bandwidth();
     const width = xScale.bandwidth();
 
     return (
       <PoseGroup animateOnMount={animated}>
-        {data.map((pair, i) =>
-          pair.data.map((val, ii) => (
-            <PoseSVGGElement key={`${id}-${i}-${ii}`}>
-              <CloneElement<HeatmapCellProps>
-                element={cell}
-                animated={animated}
-                cellIndex={i + ii}
-                x={xScale(pair.key)}
-                y={yScale(val.x)}
-                fill={valueScale(val.value)}
-                width={width}
-                height={height}
-                data={val}
-              />
-            </PoseSVGGElement>
-          ))
+        {data.map((row, rowIndex) =>
+          row.data.map((cell, cellIndex) =>
+            this.renderCell({
+              height,
+              width,
+              valueScale,
+              row,
+              cell,
+              rowIndex,
+              cellIndex
+            })
+          )
         )}
       </PoseGroup>
     );

--- a/src/Heatmap/HeatmapSeries/HeatmapCell.tsx
+++ b/src/Heatmap/HeatmapSeries/HeatmapCell.tsx
@@ -1,12 +1,12 @@
 import React, { Component, Fragment, createRef } from 'react';
-import { ChartTooltip, ChartTooltipProps } from '../common/TooltipArea';
-import { CloneElement } from '../common/utils/children';
+import { ChartTooltip, ChartTooltipProps } from '../../common/TooltipArea';
+import { CloneElement } from '../../common/utils/children';
 import bind from 'memoize-bind';
 import { PosedCell } from './PosedCell';
 import {
   constructFunctionProps,
   PropFunctionTypes
-} from '../common/utils/functions';
+} from '../../common/utils/functions';
 
 export type HeatmapCellProps = {
   x: number;

--- a/src/Heatmap/HeatmapSeries/HeatmapSeries.tsx
+++ b/src/Heatmap/HeatmapSeries/HeatmapSeries.tsx
@@ -1,12 +1,12 @@
 import React, { Component } from 'react';
 import { HeatmapCell, HeatmapCellProps } from './HeatmapCell';
 import { scaleQuantile } from 'd3-scale';
-import { uniqueBy } from '../common/utils/array';
+import { uniqueBy } from '../../common/utils/array';
 import { extent } from 'd3-array';
 import { PoseGroup } from 'react-pose';
-import { PoseSVGGElement } from 'common/utils/animations';
+import { PoseSVGGElement } from '../../common/utils/animations';
 import { memoize } from 'lodash-es';
-import { CloneElement } from '../common/utils/children';
+import { CloneElement } from '../../common/utils/children';
 
 export interface HeatmapSeriesProps {
   padding: number;
@@ -15,6 +15,7 @@ export interface HeatmapSeriesProps {
   xScale: any;
   yScale: any;
   colorScheme: any;
+  emptyColor: string;
   animated: boolean;
   cell: JSX.Element;
 }
@@ -23,17 +24,18 @@ export class HeatmapSeries extends Component<HeatmapSeriesProps> {
   static defaultProps: Partial<HeatmapSeriesProps> = {
     padding: 0.1,
     animated: true,
+    emptyColor: 'rgba(200,200,200,0.08)',
     colorScheme: ['rgba(28, 107, 86, 0.5)', '#2da283'],
     cell: <HeatmapCell />
   };
 
-  getValueScale = memoize((data, colorScheme) => {
+  getValueScale = memoize((data, colorScheme, emptyColor) => {
     const valueDomain = extent(uniqueBy(data, d => d.data, d => d.value));
 
     return point => {
       // For 0 values, lets show a placeholder fill
-      if (point === 0 || point === undefined || point === null) {
-        return 'rgba(200,200,200,0.08)';
+      if (point === undefined || point === null) {
+        return emptyColor;
       }
 
       return scaleQuantile<string>()
@@ -67,9 +69,16 @@ export class HeatmapSeries extends Component<HeatmapSeriesProps> {
   }
 
   render() {
-    const { xScale, yScale, data, colorScheme, animated } = this.props;
+    const {
+      xScale,
+      yScale,
+      data,
+      colorScheme,
+      animated,
+      emptyColor
+    } = this.props;
 
-    const valueScale = this.getValueScale(data, colorScheme);
+    const valueScale = this.getValueScale(data, colorScheme, emptyColor);
     const height = yScale.bandwidth();
     const width = xScale.bandwidth();
 

--- a/src/Heatmap/HeatmapSeries/PosedCell.ts
+++ b/src/Heatmap/HeatmapSeries/PosedCell.ts
@@ -1,5 +1,5 @@
 import posed from 'react-pose';
-import { transition } from '../common/utils/animations';
+import { transition } from '../../common/utils/animations';
 
 export const PosedCell = posed.rect({
   enter: {

--- a/src/Heatmap/HeatmapSeries/index.ts
+++ b/src/Heatmap/HeatmapSeries/index.ts
@@ -1,0 +1,2 @@
+export * from './HeatmapSeries';
+export * from './HeatmapCell';

--- a/src/Heatmap/calendarUtils.ts
+++ b/src/Heatmap/calendarUtils.ts
@@ -1,0 +1,75 @@
+import { range, max } from 'd3-array';
+import moment from 'moment';
+import { ChartShallowDataShape } from '../common/data';
+
+export type CalendarView = 'year' | 'month';
+
+export const buildDataScales = (
+  rawData: ChartShallowDataShape[],
+  view: CalendarView
+) => {
+  // Get the most recent date to get the range from
+  // From the end date, lets find the start year/month of that
+  // From that start year/month, lets find the end year/month for our bounds
+  const endDate = max(rawData, d => d.key);
+  const start = moment(endDate).startOf(view);
+  const end = start.clone().endOf(view);
+
+  // Base on the view type, swap out some ranges
+  const xDomainRange = view === 'year' ? 53 : 5;
+
+  // Build our x/y domains for days of week + number of weeks in year
+  const yDomain = range(7).reverse();
+  const xDomain = range(xDomainRange);
+
+  // Filter out dates that are not in the start/end ranges
+  // and turn them into something our chart can read
+  const dates = rawData
+    .filter(
+      d =>
+        moment(d.key as Date).isAfter(start) &&
+        moment(d.key as Date).isBefore(end)
+    )
+    .map(d => ({
+      key: moment(d.key as Date).startOf('day'),
+      data: d.data
+    }));
+
+  // Find the first day of the duration and subtract the delta
+  const firstDayOfStart = start.weekday();
+  const curDate = start.clone().subtract(firstDayOfStart, 'days');
+  const rows = [];
+
+  // Build out the dataset for the n duration
+  for (let week = 0; week < xDomainRange; week++) {
+    const row = {
+      key: week,
+      data: []
+    };
+
+    for (let day = 0; day <= 6; day++) {
+      const dayValue = dates.find(d => d.key.isSame(curDate));
+
+      row.data.push({
+        key: day,
+        data: dayValue ? dayValue.data : undefined,
+        meta: {
+          date: curDate.clone().toDate(),
+          start: start.toDate(),
+          end: end.toDate()
+        }
+      });
+
+      curDate.add(1, 'day');
+    }
+
+    rows.push(row);
+  }
+
+  return {
+    data: rows,
+    yDomain,
+    xDomain,
+    start
+  };
+};

--- a/src/Heatmap/index.ts
+++ b/src/Heatmap/index.ts
@@ -1,3 +1,4 @@
 export * from './Heatmap';
 export * from './HeatmapSeries';
 export * from './HeatmapCell';
+export * from './CalendarHeatmap';

--- a/src/Heatmap/index.ts
+++ b/src/Heatmap/index.ts
@@ -1,4 +1,4 @@
 export * from './Heatmap';
 export * from './HeatmapSeries';
-export * from './HeatmapCell';
 export * from './CalendarHeatmap';
+export * from './calendarUtils';

--- a/src/common/Axis/LinearAxis/LinearAxis.tsx
+++ b/src/common/Axis/LinearAxis/LinearAxis.tsx
@@ -13,7 +13,7 @@ export interface LinearAxisDimensionChanged {
 }
 
 export interface LinearAxisProps {
-  domain?: [ChartDataTypes, ChartDataTypes];
+  domain?: ChartDataTypes[];
   scaled?: boolean;
   roundDomains?: boolean;
   type: 'value' | 'time' | 'category' | 'duration';

--- a/src/common/data/builder.tsx
+++ b/src/common/data/builder.tsx
@@ -58,6 +58,7 @@ export function buildNestedChartData(
       if (idx === -1) {
         result.push({
           key,
+          meta: point.meta,
           data: []
         });
 
@@ -77,7 +78,7 @@ export function buildNestedChartData(
       result[idx].data.push({
         key,
         value: normalizeValueForFormatting(nestedPoint.data),
-        meta: point.meta,
+        meta: nestedPoint.meta,
         id: point.id,
         x,
         x0: isVertical ? x : 0,


### PR DESCRIPTION
This PR:

- Add Year/Month Calendar Heatmaps
- Fix `meta` for deep values not being passed correctly
- Updates `domain` on linear axis to accept n number of values
- Add ability to pass empty heatmap color
- Expose `cell` in `series` of heatmap
- Add ability to pass style/class callbacks to cell
- Tweak domain ranges to just `range` from `rangeRound` in heatmap
- Tweak tooltip offsets for heatmaps
