### PR TITLE
Fix PieArcSeries's label prop to allow null

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "reaviz",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/PieChart/PieArcSeries/PieArcSeries.tsx
+++ b/src/PieChart/PieArcSeries/PieArcSeries.tsx
@@ -18,7 +18,7 @@ export interface PieArcSeriesProps {
   explode: boolean;
   height: number;
   width: number;
-  label?: JSX.Element;
+  label?: JSX.Element | null;
   arc: JSX.Element;
   colorScheme: ((data, index: number) => string) | string[];
 }

--- a/src/PieChart/PieChart.story.tsx
+++ b/src/PieChart/PieChart.story.tsx
@@ -116,7 +116,7 @@ storiesOf('Charts/Pie/Donut', module)
           series={
             <PieArcSeries
               doughnut={true}
-              label={undefined}
+              label={null}
               colorScheme={chroma
                 .scale(['#4dd0e1', '#1976d2'])
                 .colors(categoryData.length)}


### PR DESCRIPTION
To be able to not show the pie chart's labels, the label prop of PieArcSeries needs to accept null b/c undefined will be override with the default value. So reverted the previous fix of PieChart.story.tsx and fixed PieArcSeries.tsx.