### PR TITLE
Fix the diverging chart to render positive bars only case properly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "reaviz",
-  "version": "3.0.8",
+  "version": "3.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -15429,9 +15429,9 @@
       }
     },
     "rdk": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/rdk/-/rdk-1.0.7.tgz",
-      "integrity": "sha512-PG31ZCzF+b60/MbB0HrAsUO5QpBSKBqqhxl8NKzi45iVUsE1AxGFfAyOUl53H4j2CsPgkrX6KgNPQFrh5CpUHA==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/rdk/-/rdk-1.0.8.tgz",
+      "integrity": "sha512-Urug0E76WxCDDNG47v1aAcqPwRXcvKaqMqKBuFI/ZGUmGkiQtij2tV+eQgHBELWaBDdwdjYH2raTVEygDWi3EQ==",
       "requires": {
         "classnames": "^2.2.6",
         "memoize-bind": "^1.0.3",

--- a/src/common/utils/domains.ts
+++ b/src/common/utils/domains.ts
@@ -26,7 +26,7 @@ export function getYDomain({ scaled = false, data }): number[] {
 
   // If dealing w/ negative numbers, we should
   // normalize the top and bottom values
-  if (startY < 0) {
+  if (startY <= 0) {
     const posStart = -startY;
     const maxNum = Math.max(posStart, endY);
 


### PR DESCRIPTION
Before:
<img width="970" alt="Screen Shot 2019-09-17 at 10 27 40 AM" src="https://user-images.githubusercontent.com/2556027/65064704-d44fbb80-d935-11e9-95e2-ddc02bbcf5c0.png">

After:
<img width="967" alt="Screen Shot 2019-09-17 at 10 26 15 AM" src="https://user-images.githubusercontent.com/2556027/65064721-de71ba00-d935-11e9-9bd2-a811c67b9344.png">

