### PR TITLE
Convert Radial Bar Chart to use TooltipArea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 6.0.0 - 11/12/19
+- [BREAKING] Move `RadialBarChart` to use `TooltipArea` vs `Tooltip` on each bar.
+- [Fix] Default `RadialBarChart` to one color
+- [Perf] Improve performance of `TooltipArea` data parsing using memoization
+- [Chore] Remove unused state value from `RadialAreaSeries`
+- [Docs] Add docs to `Tooltip`, `TooltipArea`, `TooltipTemplate`, `RadialPointSeries`
+
 # 5.3.5 - 11/12/19
 - [Fix] Fix area ponts not matching area color
 - [Chore] Upgrade depedencies

--- a/src/RadialAreaChart/RadialAreaSeries/RadialAreaSeries.tsx
+++ b/src/RadialAreaChart/RadialAreaSeries/RadialAreaSeries.tsx
@@ -95,7 +95,6 @@ export interface RadialAreaSeriesProps {
 
 interface RadialAreaSeriesState {
   activeValues?: any;
-  activePoint?: number;
 }
 
 export class RadialAreaSeries extends Component<
@@ -126,14 +125,12 @@ export class RadialAreaSeries extends Component<
 
   onValueEnter(event: TooltipAreaEvent) {
     this.setState({
-      activePoint: event.pointX,
       activeValues: event.value
     });
   }
 
   onValueLeave() {
     this.setState({
-      activePoint: undefined,
       activeValues: undefined
     });
   }

--- a/src/RadialAreaChart/RadialAreaSeries/RadialPointSeries.tsx
+++ b/src/RadialAreaChart/RadialAreaSeries/RadialPointSeries.tsx
@@ -9,13 +9,44 @@ import { CloneElement } from '../../common/utils';
 import isEqual from 'is-equal';
 
 export interface RadialPointSeriesProps {
+  /**
+   * Whether the points are animated or not.
+   */
   animated: boolean;
+
+  /**
+   * Color scheme.
+   */
   color: any;
+
+  /**
+   * Active values set by parent.
+   */
   activeValues?: any;
+
+  /**
+   * Parsed data object.
+   */
   data: ChartInternalShallowDataShape[];
+
+  /**
+   * D3 X-Scale.
+   */
   yScale: any;
+
+  /**
+   * D3 Y-Scale.
+   */
   xScale: any;
+
+  /**
+   * When to show the point.
+   */
   show: boolean | 'hover' | 'first' | 'last';
+
+  /**
+   * Point react component.
+   */
   point: ReactElement<RadialScatterPointProps, typeof RadialScatterPoint>;
 }
 

--- a/src/RadialBarChart/RadialBarChart.story.tsx
+++ b/src/RadialBarChart/RadialBarChart.story.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { RadialBarChart } from './RadialBarChart';
-import { largeCategoryData } from '../../demo';
+import { largeCategoryData, medDateData } from '../../demo';
 import { number, boolean, object, select } from '@storybook/addon-knobs';
 import { RadialBarSeries, RadialBar } from './RadialBarSeries';
 import {
@@ -31,8 +31,9 @@ storiesOf('Demos|Bar Chart/Radial', module)
         },
         'inside'
       );
-      const data = object('Data', largeCategoryData);
+      const data = object('Data', medDateData);
       const gradient = hasGradient ? RadialBar.defaultProps.gradient : false;
+      const colorScheme = schemes[color][0];
 
       return (
         <RadialBarChart
@@ -43,7 +44,7 @@ storiesOf('Demos|Bar Chart/Radial', module)
           series={
             <RadialBarSeries
               animated={animated}
-              colorScheme={color}
+              colorScheme={colorScheme}
               bar={<RadialBar curved={curved} gradient={gradient} />}
             />
           }

--- a/src/RadialBarChart/RadialBarChart.tsx
+++ b/src/RadialBarChart/RadialBarChart.tsx
@@ -99,6 +99,8 @@ export class RadialBarChart extends Component<RadialBarChartProps> {
           element={series}
           id={id}
           data={data}
+          height={chartHeight}
+          width={chartWidth}
           xScale={xScale}
           yScale={yScale}
           innerRadius={innerRadius}

--- a/src/common/Tooltip/Tooltip.tsx
+++ b/src/common/Tooltip/Tooltip.tsx
@@ -13,16 +13,59 @@ import { motion } from 'framer-motion';
 const tooltips: Tooltip[] = [];
 
 export interface TooltipProps {
+  /**
+   * Content for the tooltip.
+   */
   content: any;
+
+  /**
+   * Reference of the tooltip to align to.
+   */
   reference?: ReferenceObject | HTMLElement | any;
+
+  /**
+   * Popperjs placement.
+   */
   placement: Placement;
+
+  /**
+   * Delay before showing tooltip.
+   */
   enterDelay: number;
+
+  /**
+   * Delay before closing tooltip.
+   */
   leaveDelay: number;
+
+  /**
+   * Popperjs modifiers.
+   */
   modifiers?: any;
+
+  /**
+   * External setter for visibility.
+   */
   visible: boolean;
+
+  /**
+   * Additiona CSS classnames.
+   */
   className?: any;
+
+  /**
+   * How the tooltip will be triggered.
+   */
   trigger: TriggerTypes[] | TriggerTypes;
+
+  /**
+   * Whether the tooltip is disabled.
+   */
   disabled?: boolean;
+
+  /**
+   * Whether the tooltip should move with the cursor or not.
+   */
   followCursor?: boolean;
 }
 
@@ -42,13 +85,9 @@ export class Tooltip extends Component<TooltipProps, TooltipState> {
 
   timeout: any;
 
-  constructor(props: TooltipProps) {
-    super(props);
-
-    this.state = {
-      visible: props.visible
-    };
-  }
+  state: TooltipState = {
+    visible: this.props.visible
+  };
 
   componentDidUpdate(prevProps: TooltipProps) {
     const { visible } = this.props;
@@ -109,9 +148,9 @@ export class Tooltip extends Component<TooltipProps, TooltipState> {
     return (
       <motion.div
         className={classNames(css.tooltip, className)}
-        initial={{ opacity: 0, scale: .3 }}
+        initial={{ opacity: 0, scale: 0.3 }}
         animate={{ opacity: 1, scale: 1 }}
-        exit={{ opacity: 0, scale: .3 }}
+        exit={{ opacity: 0, scale: 0.3 }}
       >
         {children}
       </motion.div>

--- a/src/common/Tooltip/TooltipTemplate.tsx
+++ b/src/common/Tooltip/TooltipTemplate.tsx
@@ -16,8 +16,19 @@ interface MultipleTooltipValues {
 }
 
 interface TooltipTemplateProps {
+  /**
+   * Tooltip data value.
+   */
   value?: SingleTooltipValue | MultipleTooltipValues;
+
+  /**
+   * Color scheme to apply.
+   */
   color?: any;
+
+  /**
+   * Additional CSS classes to apply.
+   */
   className?: any;
 }
 


### PR DESCRIPTION
- [BREAKING] Move `RadialBarChart` to use `TooltipArea` vs `Tooltip` on each bar.
- [Fix] Default `RadialBarChart` to one color
- [Perf] Improve performance of `TooltipArea` data parsing using memoization
- [Chore] Remove unused state value from `RadialAreaSeries`
- [Docs] Add docs to `Tooltip`, `TooltipArea`, `TooltipTemplate`, `RadialPointSeries`